### PR TITLE
Add option for different request path (different from hardcoded '/proxy').

### DIFF
--- a/src/server/settings.json.default
+++ b/src/server/settings.json.default
@@ -3,6 +3,7 @@
   "node_ws_url":            "ws://127.0.0.1:57000",
   "http_port":              9950,
   "https_port":             9951,
+  "request_path":           "/proxy",
   "websocket_http_port":    9952,
   "websocket_https_port":   9953,
   "use_auth":               false,


### PR DESCRIPTION
The proxy accepts RPC commands on the URL `https://localhost:port/proxy`, where port is configurable, but the `/proxy` request path is not.
Introduce a config option `request_path` to make this configurable:
- `/proxy` (or `proxy`) for default `https://localhost:port/proxy`
- `/` for `https://localhost:port`
