### PR TITLE
Uses set user settings

### DIFF
--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -1,0 +1,30 @@
+class MockResponse {
+    statusCode: number | null = null
+    jsonResponse: any | null = null
+
+    status(statusCode: number): MockResponse {
+        this.statusCode = statusCode
+        return this;
+    }
+    json(json: any): MockResponse {
+        this.jsonResponse = json
+        return this;
+    }
+}
+
+test('processRequest should fail at unreachable node', async () => {
+    process.env.OVERRIDE_USE_HTTP = 'false'
+    const proxy = require('../proxy')
+
+    let body = {
+        action: 'block_info'
+    }
+    let request: any = {}
+    let mockResponse: MockResponse = new MockResponse()
+
+    await proxy.processRequest(body, request, mockResponse)
+    expect(mockResponse.statusCode).toBe(500)
+    expect(mockResponse.jsonResponse).toStrictEqual({
+        error: 'Error: Connection error: FetchError: request to http://[::1]:7076/ failed, reason: connect ECONNREFUSED ::1:7076'
+    })
+})

--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -37,6 +37,23 @@ test('processRequest should fail at unreachable node', async () => {
     })
 })
 
+test('processRequest should fail on invalid command', async () => {
+    process.env.OVERRIDE_USE_HTTP = 'false'
+    const proxy = require('../proxy')
+
+    let body = {
+        action: 'not_supported_command'
+    }
+    let request: any = {}
+    let mockResponse: MockResponse = new MockResponse()
+
+    await proxy.processRequest(body, request, mockResponse)
+    expect(mockResponse.statusCode).toBe(500)
+    expect(mockResponse.jsonResponse).toStrictEqual({
+        error: 'Action not_supported_command not allowed'
+    })
+})
+
 afterAll(() => {
     fs.unlinkSync(filePath)
 })

--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+
 class MockResponse {
     statusCode: number | null = null
     jsonResponse: any | null = null
@@ -11,6 +13,12 @@ class MockResponse {
         return this;
     }
 }
+
+const filePath = 'settings.json';
+
+beforeAll(() => {
+    fs.copyFileSync(`${filePath}.default`, filePath, )
+})
 
 test('processRequest should fail at unreachable node', async () => {
     process.env.OVERRIDE_USE_HTTP = 'false'
@@ -27,4 +35,8 @@ test('processRequest should fail at unreachable node', async () => {
     expect(mockResponse.jsonResponse).toStrictEqual({
         error: 'Error: Connection error: FetchError: request to http://[::1]:7076/ failed, reason: connect ECONNREFUSED ::1:7076'
     })
+})
+
+afterAll(() => {
+    fs.unlinkSync(filePath)
 })

--- a/src/server/src/__test__/proxy_default.test.ts
+++ b/src/server/src/__test__/proxy_default.test.ts
@@ -3,7 +3,7 @@ export {}
 const expectedDefaultSettings = [
     'PROXY SETTINGS:\n-----------',
     'Node url: http://[::1]:7076',
-    'Websocket url: ws://127.0.0.1:57000',
+    'Websocket url: ws://127.0.0.1:7078',
     'Http port: 9950',
     'Https port: 9951',
     'Request path: /proxy',

--- a/src/server/src/__test__/user_settings.test.ts
+++ b/src/server/src/__test__/user_settings.test.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+import {readUserSettings} from "../user-settings";
+
+const filePath = 'user_settings.json';
+
+beforeAll(() => {
+    fs.copyFileSync(`${filePath}.default`, filePath, )
+})
+
+test('parseUserSettings should parse to Map', async () => {
+
+    const settings = readUserSettings(filePath)
+    expect(Array.from(settings.values()).length).toBe(2)
+    const userSettings = settings.get('user2')
+    expect(userSettings).toBeDefined()
+    // @ts-ignore
+    expect(userSettings.allowed_commands.length).toBe(4)
+    // @ts-ignore
+    expect(Array.from(userSettings.cached_commands.values()).length).toBe(1)
+    // @ts-ignore
+    expect(Array.from(userSettings.limited_commands.values()).length).toBe(4)
+})
+
+afterAll(() => {
+    fs.unlinkSync(filePath)
+})

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -542,8 +542,8 @@ function myAuthorizer(username: string, password: string) {
           userSettings.use_cache = value.use_cache
           userSettings.use_output_limiter = value.use_output_limiter
           userSettings.allowed_commands = value.allowed_commands
-          userSettings.cached_commands = value.cached_commands
-          userSettings.limited_commands = value.limited_commands
+          userSettings.cached_commands = value.cached_commands ? new Map(Object.entries(value.cached_commands)) : new Map<Command, number>()
+          userSettings.limited_commands = value.limited_commands ? new Map(Object.entries(value.limited_commands)) : new Map<Command, number>()
           userSettings.log_level = value.log_level
           return;
         }

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -186,19 +186,23 @@ const loadSettings: () => ProxySettings = () => {
     const requestPath = defaultSettings.request_path || settings.request_path
     const normalizedRequestPath = requestPath.startsWith('/') ? requestPath : '/' + requestPath
     const mergedSettings: ProxySettings = {...defaultSettings, ...settings, request_path: normalizedRequestPath }
-
+    const fixedSettings: ProxySettings = {
+      ...mergedSettings,
+      cached_commands: new Map(Object.entries(mergedSettings.cached_commands)),
+      limited_commands: new Map(Object.entries(mergedSettings.cached_commands)),
+    }
     // Clone default settings for custom user specific vars, to be used if no auth
-    if (!mergedSettings.use_auth) {
+    if (!fixedSettings.use_auth) {
       userSettings = {
-        use_cache: mergedSettings.use_cache,
-        use_output_limiter: mergedSettings.use_output_limiter,
-        allowed_commands: mergedSettings.allowed_commands,
-        cached_commands: mergedSettings.cached_commands,
-        limited_commands: mergedSettings.limited_commands,
-        log_level: mergedSettings.log_level
+        use_cache: fixedSettings.use_cache,
+        use_output_limiter: fixedSettings.use_output_limiter,
+        allowed_commands: fixedSettings.allowed_commands,
+        cached_commands: fixedSettings.cached_commands,
+        limited_commands: fixedSettings.limited_commands,
+        log_level: fixedSettings.log_level
       }
     }
-    return mergedSettings
+    return fixedSettings
   }
   catch(e) {
     console.log("Could not read settings.json", e)
@@ -293,9 +297,7 @@ function logSettings(logger: (...data: any[]) => void) {
 }
 logSettings(console.log)
 
-module.exports = {
-  logSettings: logSettings
-}
+
 // ---
 
 // Read dpow and bpow credentials from file
@@ -983,6 +985,11 @@ async function processRequest(query: any, req: Request, res: Response) {
     res.status(500).json({error: err.toString()})
     logThis("Node conection error: " + err.toString(), log_levels.warning)
   }
+}
+
+module.exports = {
+  logSettings: logSettings,
+  processRequest: processRequest
 }
 
 var websocket_servers = []

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -65,13 +65,14 @@ var ws: ReconnectingWebSocket | null = null
 var global_tracked_accounts: string[] = [] // the accounts to track in websocket (synced with database)
 var websocket_connections: Map<string, connection> = new Map<string, connection>() // active ws connections
 
-let defaultUserSettings: UserSettings | undefined
-var user_use_cache: boolean | null = null
-var user_use_output_limiter: boolean | null = null
-var user_allowed_commands: string[] | null = null
-var user_cached_commands: CachedCommands | null = null
-var user_limited_commands: LimitedCommands | null = null
-var user_log_level: LogLevel | null = null
+let userSettings: UserSettings = {
+  allowed_commands: null,
+  cached_commands: null,
+  limited_commands: null,
+  log_level: 'info',
+  use_cache: false,
+  use_output_limiter: false
+}
 var dpow_user: string | null = null
 var dpow_key: string | null = null
 var bpow_user: string | null = null
@@ -188,7 +189,7 @@ const loadSettings: () => ProxySettings = () => {
 
     // Clone default settings for custom user specific vars, to be used if no auth
     if (!mergedSettings.use_auth) {
-      defaultUserSettings = {
+      userSettings = {
         use_cache: mergedSettings.use_cache,
         use_output_limiter: mergedSettings.use_output_limiter,
         allowed_commands: mergedSettings.allowed_commands,
@@ -521,12 +522,12 @@ if (settings.use_cache) {
 // To verify username and password provided via basicAuth. Support multiple users
 function myAuthorizer(username: string, password: string) {
   // Set default settings specific for authenticated users
-  user_use_cache = settings.use_cache
-  user_use_output_limiter = settings.use_output_limiter
-  user_allowed_commands = settings.allowed_commands
-  user_cached_commands = settings.cached_commands
-  user_limited_commands = settings.limited_commands
-  user_log_level = settings.log_level
+  userSettings.use_cache = settings.use_cache
+  userSettings.use_output_limiter = settings.use_output_limiter
+  userSettings.allowed_commands = settings.allowed_commands
+  userSettings.cached_commands = settings.cached_commands
+  userSettings.limited_commands = settings.limited_commands
+  userSettings.log_level = settings.log_level
 
   var valid_user: boolean = false
   for (const [key, value] of Object.entries(users)) {
@@ -536,12 +537,12 @@ function myAuthorizer(username: string, password: string) {
       // Override default settings if exists
       user_settings.forEach((value: UserSettings, key: string, map: UserSettingsConfig) => {
         if(key === username) {
-          user_use_cache = value.use_cache
-          user_use_output_limiter = value.use_output_limiter
-          user_allowed_commands = value.allowed_commands
-          user_cached_commands = value.cached_commands
-          user_limited_commands = value.limited_commands
-          user_log_level = value.log_level
+          userSettings.use_cache = value.use_cache
+          userSettings.use_output_limiter = value.use_output_limiter
+          userSettings.allowed_commands = value.allowed_commands
+          userSettings.cached_commands = value.cached_commands
+          userSettings.limited_commands = value.limited_commands
+          userSettings.log_level = value.log_level
           return;
         }
       })
@@ -604,7 +605,7 @@ function updateTrackedAccounts() {
 
 // Log function
 function logThis(str: string, level: LogLevel) {
-  if (user_log_level == log_levels.info || level == user_log_level) {
+  if (userSettings.log_level === log_levels.info || level == userSettings.log_level) {
     if (level == log_levels.info) {
       console.info(str)
     }
@@ -742,7 +743,7 @@ async function processRequest(query: any, req: Request, res: Response) {
   }
 
   // Block non-allowed RPC commands
-  if (!query.action || user_allowed_commands?.indexOf(query.action) === -1) {
+  if (!query.action || userSettings.allowed_commands?.indexOf(query.action) === -1) {
     logThis('RPC request is not allowed: ' + query.action, log_levels.info)
     return res.status(500).json({ error: `Action ${query.action} not allowed`})
   }
@@ -933,8 +934,8 @@ async function processRequest(query: any, req: Request, res: Response) {
   // ---
 
   // Read cache for current request action, if there is one
-  if (user_use_cache) {
-    const value: number | undefined = user_cached_commands?.get(query.action)
+  if (userSettings.use_cache) {
+    const value: number | undefined = userSettings.cached_commands?.get(query.action)
     if(value !== undefined) {
       const cachedValue = rpcCache?.get(query.action)
       if (Tools.isValidJson(cachedValue)) {
@@ -949,8 +950,8 @@ async function processRequest(query: any, req: Request, res: Response) {
   }
 
   // Limit response count (if count parameter is provided)
-  if (user_use_output_limiter) {
-    const value: number | undefined = user_limited_commands?.get(query.action)
+  if (userSettings.use_output_limiter) {
+    const value: number | undefined = userSettings.limited_commands?.get(query.action)
     if(value !== undefined) {
       if (parseInt(query.count) > value || !("count" in query)) {
         query.count = value
@@ -966,7 +967,7 @@ async function processRequest(query: any, req: Request, res: Response) {
     let data = await Tools.postData(query, settings.node_url, API_TIMEOUT)
     // Save cache if applicable
     if (settings.use_cache) {
-      const value: number | undefined = user_cached_commands?.get(query.action)
+      const value: number | undefined = userSettings.cached_commands?.get(query.action)
       if(value !== undefined) {
         if (!rpcCache?.set(query.action, data, value)) {
           logThis("Failed saving cache for " + query.action, log_levels.warning)

--- a/src/server/src/user-settings.ts
+++ b/src/server/src/user-settings.ts
@@ -4,9 +4,9 @@ import * as Fs from "fs";
 export interface UserSettings {
     use_cache: boolean;
     use_output_limiter: boolean;
-    allowed_commands: string[] | null;
-    cached_commands: CachedCommands | null;
-    limited_commands: LimitedCommands | null;
+    allowed_commands: string[];
+    cached_commands: CachedCommands;
+    limited_commands: LimitedCommands;
     log_level: LogLevel;
 }
 

--- a/src/server/src/user-settings.ts
+++ b/src/server/src/user-settings.ts
@@ -1,5 +1,6 @@
 import {CachedCommands, Command, LimitedCommands, LogLevel} from "./common-settings";
 import * as Fs from "fs";
+import ProxySettings from "./proxy-settings";
 
 export interface UserSettings {
     use_cache: boolean;
@@ -12,8 +13,31 @@ export interface UserSettings {
 
 export type UserSettingsConfig = Map<string, UserSettings>
 
-const EMPTY_USER_SETTINGS = new Map<string, UserSettings>()
+/** Clone default settings for custom user specific vars, to be used if no auth */
+export function loadDefaultUserSettings(settings: ProxySettings): UserSettings {
+    const defaultUserSettings: UserSettings = {
+        allowed_commands: [],
+        cached_commands: new Map<Command, number>(),
+        limited_commands: new Map<Command, number>(),
+        log_level: 'info',
+        use_cache: false,
+        use_output_limiter: false
+    };
+    if (!settings.use_auth) {
+        return {
+            use_cache: settings.use_cache,
+            use_output_limiter: settings.use_output_limiter,
+            allowed_commands: settings.allowed_commands,
+            cached_commands: settings.cached_commands,
+            limited_commands: settings.limited_commands,
+            log_level: settings.log_level
+        }
+    } else {
+        return defaultUserSettings
+    }
+}
 
+/** Read user settings from file, override default settings if they exist for specific users */
 export function readUserSettings(settingsPath: string): UserSettingsConfig {
     try {
         const userSettings: any = JSON.parse(Fs.readFileSync(settingsPath, 'utf-8'))
@@ -25,6 +49,6 @@ export function readUserSettings(settingsPath: string): UserSettingsConfig {
         return parsed
     } catch (e) {
         console.log("Could not read user_settings.json, returns empty settings.", e)
-        return EMPTY_USER_SETTINGS;
+        return new Map<string, UserSettings>();
     }
 }

--- a/src/server/src/user-settings.ts
+++ b/src/server/src/user-settings.ts
@@ -1,4 +1,5 @@
-import {CachedCommands, LimitedCommands, LogLevel} from "./common-settings";
+import {CachedCommands, Command, LimitedCommands, LogLevel} from "./common-settings";
+import * as Fs from "fs";
 
 export interface UserSettings {
     use_cache: boolean;
@@ -10,3 +11,20 @@ export interface UserSettings {
 }
 
 export type UserSettingsConfig = Map<string, UserSettings>
+
+const EMPTY_USER_SETTINGS = new Map<string, UserSettings>()
+
+export function readUserSettings(settingsPath: string): UserSettingsConfig {
+    try {
+        const userSettings: any = JSON.parse(Fs.readFileSync(settingsPath, 'utf-8'))
+        const parsed: UserSettingsConfig = new Map(Object.entries(userSettings))
+        parsed.forEach((v: UserSettings, k: string, m: Map<string, UserSettings>) => {
+            v.cached_commands = v.cached_commands ? new Map(Object.entries(v.cached_commands)) : new Map<Command, number>()
+            v.limited_commands = v.limited_commands ? new Map(Object.entries(v.limited_commands)) : new Map<Command, number>()
+        })
+        return parsed
+    } catch (e) {
+        console.log("Could not read user_settings.json, returns empty settings.", e)
+        return EMPTY_USER_SETTINGS;
+    }
+}

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
**PR ready for review again.**

Issue was that ie. `cached_commands` got de-serialized as Object and not Map. This PR addresses this by manually constructing a map for these data types after de-serializing from the config file. Moved reading user-files into `user-settings.ts` to make it easier to construct tests for these cases.

Also made a test for process_request (which was what I started testing). This can be expanded to check for certain headers or json-responses in various fail cases. Currently it only checks that a response gives 500 due to not being able to reach a node.