### PR TITLE
Rpc cache types

### DIFF
--- a/src/server/src/__test__/pending_response.test.ts
+++ b/src/server/src/__test__/pending_response.test.ts
@@ -1,0 +1,17 @@
+const expectedResponse = `
+    {
+      "blocks" : {
+        "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F": {
+          "amount": "6000000000000000000000000000000",
+          "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
+        }
+      }
+    }
+`
+
+test('pending response should deserialize to Record', async () => {
+    const pending: PendingResponse = JSON.parse(expectedResponse)
+    const pendingBlock = pending.blocks['000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F']
+    expect(pendingBlock.amount).toStrictEqual('6000000000000000000000000000000')
+    expect(pendingBlock.source).toStrictEqual('nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr')
+})

--- a/src/server/src/node-api/node-api.ts
+++ b/src/server/src/node-api/node-api.ts
@@ -1,0 +1,48 @@
+/** @see https://docs.nano.org/commands/rpc-protocol/#active_difficulty */
+interface ActiveDifficultyResponse {
+    multiplier: string
+    network_current: string
+    network_minimum: string
+    network_receive_current: string | null
+    network_receive_minimum: string | null
+}
+
+interface ProcessDataResponse {
+    difficulty: any
+    multiplier: string
+    tokens_total: number
+    error: string | null
+}
+
+interface PendingBlock {
+    amount: string
+    source: string
+}
+
+/** @see https://docs.nano.org/commands/rpc-protocol/#pending */
+interface PendingResponse {
+    blocks: Record<string, PendingBlock>
+    error: string | null
+}
+
+/** @see https://docs.nano.org/commands/rpc-protocol/#account_info */
+interface AccountInfoResponse {
+    frontier: string
+    balance: string
+    representative: string
+    error: string | null
+}
+
+/** @see https://docs.nano.org/commands/rpc-protocol/#work_generate */
+interface WorkGenerateResponse {
+    work: string
+    difficulty: string
+    multiplier: string
+    hash: string
+}
+
+/** @see https://docs.nano.org/commands/rpc-protocol/#process */
+interface ProcessResponse {
+    hash: string
+    error: string | null
+}

--- a/src/server/src/price-api/price-api.ts
+++ b/src/server/src/price-api/price-api.ts
@@ -1,0 +1,4 @@
+
+export interface PriceResponse {
+    tokens_total: number
+}

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -909,11 +909,10 @@ async function processRequest(query: any, req: Request, res: Response) {
   if (userSettings.use_cache) {
     const value: number | undefined = userSettings.cached_commands.get(query.action)
     if(value !== undefined) {
-      const cachedValue = rpcCache?.get(query.action)
+      const cachedValue: any = rpcCache?.get(query.action)
       if (Tools.isValidJson(cachedValue)) {
         logThis("Cache requested: " + query.action, log_levels.info)
         if (tokens_left != null) {
-          // @ts-ignore what is type of cachedValue?
           cachedValue.tokens_total = tokens_left
         }
         return res.json(appendRateLimiterStatus(res, cachedValue))

--- a/src/server/src/tools.ts
+++ b/src/server/src/tools.ts
@@ -20,74 +20,72 @@ class APIError extends Error {
   }
 }
 
-// Functions to be required from another file
-module.exports = {
-  // Get data from URL. let data = await getData("url", TIMEOUT)
-  getData: async function (server: string, timeout: number) {
-    let options: any = {
-      method: 'get',
-      timeout: timeout,
-    }
+// Get data from URL. let data = await getData("url", TIMEOUT)
+export async function getData<data>(server: string, timeout: number): Promise<data> {
+  let options: any = {
+    method: 'get',
+    timeout: timeout,
+  }
 
-    let promise = new Promise(async (resolve, reject) => {
-        // https://www.npmjs.com/package/node-fetch
-        Fetch(server, options)
-          .then(checkStatus)
-          .then(res => res.json())
-          .then(json => resolve(json))
-          .catch(err => reject(new Error('Connection error: ' + err)))
-    })
-    return await promise // return promise result when finished instead of returning the promise itself, to avoid nested ".then"
-  },
-  // Post data, for example to RPC node. let data = await postData({"action":"block_count"}, "url", TIMEOUT)
-  postData: async function (data: any, server: string, timeout: number) {
-    let options: any = {
-      method: 'post',
-      body:    JSON.stringify(data),
-      headers: { 'Content-Type': 'application/json' },
-      timeout: timeout,
-    }
+  let promise = new Promise(async (resolve: (value: data) => void, reject) => {
+    // https://www.npmjs.com/package/node-fetch
+    Fetch(server, options)
+        .then(checkStatus)
+        .then(res => res.json())
+        .then(json => resolve(json))
+        .catch(err => reject(new Error('Connection error: ' + err)))
+  })
+  return await promise // return promise result when finished instead of returning the promise itself, to avoid nested ".then"
+}
 
-    let promise = new Promise(async (resolve, reject) => {
-        // https://www.npmjs.com/package/node-fetch
-        Fetch(server, options)
-          .then(checkStatus)
-          .then(res => res.json())
-          .then(json => resolve(json))
-          .catch(err => reject(new Error('Connection error: ' + err)))
-    })
-    return await promise // return promise result when finished instead of returning the promise itself, to avoid nested ".then"
-  },
-  // Check if a string is a valid JSON
-  isValidJson: function (obj: any) {
-    if (obj != null) {
-      try {
-          JSON.parse(JSON.stringify(obj))
-          return true
-      } catch (e) {
-        return false
-      }
-    }
-    else  {
+// Post data, for example to RPC node. let data = await postData({"action":"block_count"}, "url", TIMEOUT)
+export  async function postData<ResponseData>(data: any, server: string, timeout: number): Promise<ResponseData> {
+  let options: any = {
+    method: 'post',
+    body:    JSON.stringify(data),
+    headers: { 'Content-Type': 'application/json' },
+    timeout: timeout,
+  }
+
+  let promise = new Promise(async (resolve: (value: ResponseData) => void, reject) => {
+    // https://www.npmjs.com/package/node-fetch
+    Fetch(server, options)
+        .then(checkStatus)
+        .then(res => res.json())
+        .then(json => resolve(json))
+        .catch(err => reject(new Error('Connection error: ' + err)))
+  })
+  return await promise // return promise result when finished instead of returning the promise itself, to avoid nested ".then"
+}
+// Check if a string is a valid JSON
+export function isValidJson(obj: any) {
+  if (obj != null) {
+    try {
+        JSON.parse(JSON.stringify(obj))
+        return true
+    } catch (e) {
       return false
     }
-  },
-  // Add two big integers
-  bigAdd: function (input: string, value: string): string {
-    let insert = BigInt(input)
-    let val = BigInt(value)
-    return insert.add(val).toString()
-  },
-  rawToMnano: function (input: string) {
-    return isNumeric(input) ? Nano.convert(input, {from: Nano.Unit.raw, to: Nano.Unit.NANO}) : 'N/A'
-  },
-  MnanoToRaw: function (input: string) {
-    return isNumeric(input) ? Nano.convert(input, {from: Nano.Unit.NANO, to: Nano.Unit.raw}) : 'N/A'
-  },
-  // Validate nano address, both format and checksum
-  validateAddress: function (address: string) {
-    return Nano.checkAddress(address)
-  },
+  }
+  else  {
+    return false
+  }
+}
+// Add two big integers
+export function bigAdd(input: string, value: string): string {
+  let insert = BigInt(input)
+  let val = BigInt(value)
+  return insert.add(val).toString()
+}
+export function rawToMnano(input: string) {
+  return isNumeric(input) ? Nano.convert(input, {from: Nano.Unit.raw, to: Nano.Unit.NANO}) : 'N/A'
+}
+export function MnanoToRaw(input: string) {
+  return isNumeric(input) ? Nano.convert(input, {from: Nano.Unit.NANO, to: Nano.Unit.raw}) : 'N/A'
+}
+// Validate nano address, both format and checksum
+export function validateAddress(address: string) {
+  return Nano.checkAddress(address)
 }
 
 function checkStatus(res: Response) {


### PR DESCRIPTION
Fixes #22. Adds missing type definitions for node api and price api. Also noticed there is a Record type for Typescript that can replace the Map-changes in the previous PR. Added a test for this to verify that it works as expected.

Exported functions instead of module.exports. PR is best viewed with "hide whitespace changes".