### PR TITLE
Config paths as environment

### DIFF
--- a/src/server/src/__test__/my_authorizer.test.ts
+++ b/src/server/src/__test__/my_authorizer.test.ts
@@ -4,24 +4,24 @@ const filePaths = ['creds.json', 'user_settings.json'];
 
 beforeAll(() => {
     filePaths.forEach(filePath => {
-        fs.copyFileSync(`${filePath}.default`, filePath, )
+        fs.copyFileSync(`${filePath}.default`, `src/__test__/${filePath}`, )
     })
+    process.env.OVERRIDE_USE_HTTP = 'false'
+    process.env.CONFIG_CREDS_SETTINGS = 'src/__test__/creds.json'
+    process.env.CONFIG_USER_SETTINGS = 'src/__test__/user_settings.json'
 })
 
 test('myAuthorizer should authorize existing user', () => {
-    process.env.OVERRIDE_USE_HTTP = 'false'
     const authorized = require('../proxy').myAuthorizer('user1', 'user1')
     expect(authorized).toBeTruthy()
 })
 
 test('myAuthorizer should deny user with wrong password', () => {
-    process.env.OVERRIDE_USE_HTTP = 'false'
     const authorized = require('../proxy').myAuthorizer('user2', 'wrong_password')
     expect(authorized).toBeFalsy()
 })
 
 test('myAuthorizer should override with custom settings', () => {
-    process.env.OVERRIDE_USE_HTTP = 'false'
     const proxy = require('../proxy')
     proxy.myAuthorizer('user2', 'user2')
     expect(proxy.getUserSettings().allowed_commands).toStrictEqual([ 'account_history', 'account_info', 'block_info', 'block_count' ])
@@ -29,6 +29,6 @@ test('myAuthorizer should override with custom settings', () => {
 
 afterAll(() => {
     filePaths.forEach(filePath => {
-        fs.unlinkSync(filePath)
+        fs.unlinkSync(`src/__test__/${filePath}`)
     })
 })

--- a/src/server/src/__test__/my_authorizer.test.ts
+++ b/src/server/src/__test__/my_authorizer.test.ts
@@ -1,11 +1,9 @@
-import fs from "fs";
+import {copyConfigFiles, deleteConfigFiles} from "./test-commons";
 
 const filePaths = ['creds.json', 'user_settings.json'];
 
 beforeAll(() => {
-    filePaths.forEach(filePath => {
-        fs.copyFileSync(`${filePath}.default`, `src/__test__/${filePath}`, )
-    })
+    copyConfigFiles(filePaths)
     process.env.OVERRIDE_USE_HTTP = 'false'
     process.env.CONFIG_CREDS_SETTINGS = 'src/__test__/creds.json'
     process.env.CONFIG_USER_SETTINGS = 'src/__test__/user_settings.json'
@@ -27,8 +25,4 @@ test('myAuthorizer should override with custom settings', () => {
     expect(proxy.getUserSettings().allowed_commands).toStrictEqual([ 'account_history', 'account_info', 'block_info', 'block_count' ])
 })
 
-afterAll(() => {
-    filePaths.forEach(filePath => {
-        fs.unlinkSync(`src/__test__/${filePath}`)
-    })
-})
+afterAll(() => deleteConfigFiles(filePaths))

--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -17,11 +17,11 @@ class MockResponse {
 const filePath = 'settings.json';
 
 beforeAll(() => {
+    process.env.OVERRIDE_USE_HTTP = 'false'
     fs.copyFileSync(`${filePath}.default`, filePath, )
 })
 
 test('processRequest should fail at unreachable node', async () => {
-    process.env.OVERRIDE_USE_HTTP = 'false'
     const proxy = require('../proxy')
 
     let body = {
@@ -38,7 +38,6 @@ test('processRequest should fail at unreachable node', async () => {
 })
 
 test('processRequest should fail on invalid command', async () => {
-    process.env.OVERRIDE_USE_HTTP = 'false'
     const proxy = require('../proxy')
 
     let body = {

--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import {copyConfigFiles, deleteConfigFiles} from "./test-commons";
 
 class MockResponse {
     statusCode: number | null = null
@@ -14,11 +14,12 @@ class MockResponse {
     }
 }
 
-const filePath = 'settings.json';
+const filePaths = ['settings.json'];
 
 beforeAll(() => {
     process.env.OVERRIDE_USE_HTTP = 'false'
-    fs.copyFileSync(`${filePath}.default`, filePath, )
+    process.env.CONFIG_SETTINGS = 'src/__test__/settings.json'
+    copyConfigFiles(filePaths)
 })
 
 test('processRequest should fail at unreachable node', async () => {
@@ -53,6 +54,4 @@ test('processRequest should fail on invalid command', async () => {
     })
 })
 
-afterAll(() => {
-    fs.unlinkSync(filePath)
-})
+afterAll(() => deleteConfigFiles(filePaths))

--- a/src/server/src/__test__/proxy_default.test.ts
+++ b/src/server/src/__test__/proxy_default.test.ts
@@ -29,6 +29,7 @@ const expectedDefaultSettings = [
 test('log proxy settings with no config', () => {
     let settings: string[] = []
     process.env.OVERRIDE_USE_HTTP = 'false'
+    process.env.CONFIG_SETTINGS = 'src/__test__/settings.json'
     require('../proxy').logSettings((setting: string) => settings.push(setting))
     expect(settings.length).toBe(23);
     expect(settings).toStrictEqual(expectedDefaultSettings)

--- a/src/server/src/__test__/proxy_file.test.ts
+++ b/src/server/src/__test__/proxy_file.test.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import {copyConfigFiles, deleteConfigFiles} from "./test-commons";
 
 const expectedSettingsWithFile = [
     'PROXY SETTINGS:\n-----------',
@@ -85,20 +85,19 @@ const expectedSettingsWithFile = [
     'Main log level: info'
 ]
 
-const filePath = 'settings.json';
+const filePaths = ['settings.json'];
 
 beforeAll(() => {
-    fs.copyFileSync(`${filePath}.default`, filePath, )
+    process.env.OVERRIDE_USE_HTTP = 'false'
+    process.env.CONFIG_SETTINGS = 'src/__test__/settings.json'
+    copyConfigFiles(filePaths)
 })
 
 test('log proxy settings with default config from file', () => {
     let settings: string[] = []
-    process.env.OVERRIDE_USE_HTTP = 'false'
     require('../proxy').logSettings((setting: string) => settings.push(setting))
     expect(settings.length).toBe(28);
     expect(settings).toStrictEqual(expectedSettingsWithFile)
 })
 
-afterAll(() => {
-    fs.unlinkSync(filePath)
-})
+afterAll(() => deleteConfigFiles(filePaths))

--- a/src/server/src/__test__/test-commons.ts
+++ b/src/server/src/__test__/test-commons.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+
+const testFolder = 'src/__test__/';
+
+export function copyConfigFiles(filePaths: string[]) {
+    filePaths.forEach(filePath => {
+        fs.copyFileSync(`${filePath}.default`, `${testFolder}${filePath}`, )
+    })
+}
+export function deleteConfigFiles(filePaths: string[]) {
+    filePaths.forEach(filePath => {
+        fs.unlinkSync(`${testFolder}${filePath}`)
+    })
+}

--- a/src/server/src/__test__/tokens_default.test.ts
+++ b/src/server/src/__test__/tokens_default.test.ts
@@ -16,8 +16,8 @@ const expectedDefaultSettings = [
 
 test('log token settings with no config', () => {
     let settings: string[] = []
+    process.env.CONFIG_TOKEN_SETTINGS = 'src/__test__/token_settings.json'
     require('../tokens').tokenLogSettings((setting: string) => settings.push(setting))
-    console.log(settings)
     expect(settings.length).toBe(11);
     expect(settings).toStrictEqual(expectedDefaultSettings)
 });

--- a/src/server/src/__test__/tokens_file.test.ts
+++ b/src/server/src/__test__/tokens_file.test.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import {copyConfigFiles, deleteConfigFiles} from "./test-commons";
 
 const expectedDefaultSettings = [
     'TOKEN SETTINGS:\n-----------',
@@ -14,20 +14,18 @@ const expectedDefaultSettings = [
     'Token system log level: info'
 ]
 
-const filePath = 'token_settings.json';
+const filePaths = ['token_settings.json'];
 
 beforeAll(() => {
-    fs.copyFileSync(`${filePath}.default`, filePath, )
+    process.env.CONFIG_TOKEN_SETTINGS = 'src/__test__/token_settings.json'
+    copyConfigFiles(filePaths)
 })
 
 test('log tokens settings with default config from file', () => {
     let settings: string[] = []
     require('../tokens').tokenLogSettings((setting: string) => settings.push(setting))
-    console.log(settings)
     expect(settings.length).toBe(11);
     expect(settings).toStrictEqual(expectedDefaultSettings)
 });
 
-afterAll(() => {
-    fs.unlinkSync(filePath)
-})
+afterAll(() => deleteConfigFiles(filePaths))

--- a/src/server/src/__test__/user_settings.test.ts
+++ b/src/server/src/__test__/user_settings.test.ts
@@ -1,15 +1,14 @@
-import fs from "fs";
 import {readUserSettings} from "../user-settings";
+import {copyConfigFiles, deleteConfigFiles} from "./test-commons";
 
-const filePath = 'user_settings.json';
+const filePaths = ['user_settings.json'];
 
 beforeAll(() => {
-    fs.copyFileSync(`${filePath}.default`, filePath, )
+    copyConfigFiles(filePaths)
 })
 
 test('parseUserSettings should parse to Map', async () => {
-
-    const settings = readUserSettings(filePath)
+    const settings = readUserSettings('src/__test__/user_settings.json')
     expect(Object.entries(settings).length).toBe(2)
     const userSettings = settings['user2']
     expect(userSettings).toBeDefined()
@@ -18,6 +17,4 @@ test('parseUserSettings should parse to Map', async () => {
     expect(Object.entries(userSettings.limited_commands).length).toBe(4)
 })
 
-afterAll(() => {
-    fs.unlinkSync(filePath)
-})
+afterAll(() => deleteConfigFiles(filePaths))

--- a/src/server/src/common-settings.ts
+++ b/src/server/src/common-settings.ts
@@ -19,3 +19,24 @@ export interface LogData {
     date: string;
     count: number;
 }
+
+type ConfigPath = string
+export interface ConfigPaths {
+    request_stat: ConfigPath
+    token_settings: ConfigPath
+    creds: ConfigPath
+    pow_creds: ConfigPath
+    settings: ConfigPath
+    user_settings: ConfigPath
+}
+
+export function readConfigPathsFromENV(): ConfigPaths {
+    return {
+        creds: process.env.CONFIG_CREDS_SETTINGS || 'creds.json',
+        pow_creds: process.env.CONFIG_POW_CREDS_SETTINGS || 'pow_creds.json',
+        request_stat: process.env.CONFIG_REQUEST_STAT || 'request-stat.json',
+        settings: process.env.CONFIG_SETTINGS || 'settings.json',
+        token_settings: process.env.CONFIG_TOKEN_SETTINGS || 'token_settings.json',
+        user_settings: process.env.CONFIG_USER_SETTINGS || 'user_settings.json'
+    }
+}

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -22,7 +22,6 @@ require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
 
 const configPaths: ConfigPaths = readConfigPathsFromENV()
-
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
 const BasicAuth =             require('express-basic-auth')

--- a/src/server/src/tokens.ts
+++ b/src/server/src/tokens.ts
@@ -1,5 +1,5 @@
 import {TokenSettings} from "./token-settings";
-import {log_levels, LogLevel} from "./common-settings";
+import {log_levels, LogLevel, readConfigPathsFromENV} from "./common-settings";
 import {Order, OrderDB} from "./lowdb-schema";
 import {Wallet} from "nanocurrency-web/dist/lib/address-importer";
 import * as Tools from './tools'
@@ -13,6 +13,7 @@ const Fs =         require('fs')
 // const log_levels = {none:"none", warning:"warning", info:"info"}
 
 const API_TIMEOUT = 10000 // 10sec timeout for calling http APIs
+const tokenSettings = readConfigPathsFromENV().token_settings
 
 const loadSettings: () => TokenSettings = () => {
   const defaultSettings: TokenSettings = {
@@ -31,7 +32,7 @@ const loadSettings: () => TokenSettings = () => {
   // Read settings from file
 // ---
   try {
-    const readSettings: TokenSettings = JSON.parse(Fs.readFileSync('token_settings.json', 'UTF-8'))
+    const readSettings: TokenSettings = JSON.parse(Fs.readFileSync(tokenSettings, 'UTF-8'))
     return {...defaultSettings, ...readSettings}
   }
   catch(e) {


### PR DESCRIPTION
Makes it possible to read config file path from environment, fallback to original path. Fixes tests and extracts a few helper functions for creating/cleaning up config files in test.

Fixes #29