### PR TITLE
Websocket types

### DIFF
--- a/src/server/src/node-api/websocket-api.ts
+++ b/src/server/src/node-api/websocket-api.ts
@@ -1,0 +1,40 @@
+type WSTopic = 'confirmation'
+type WSAction = 'subscribe' | 'unsubscribe'
+
+interface WSNodeSubscribe {
+    action: WSAction
+    topic: WSTopic
+    ack: boolean
+    options: {
+        all_local_accounts: boolean
+        accounts: string[]
+    }
+}
+interface WSNodeReceive {
+    topic: WSTopic
+    message: {
+        account: string
+        block: {
+            link_as_account: string
+        }
+    }
+    ack: WSAction
+}
+
+interface WSMessage {
+    topic: WSTopic
+    action: WSAction
+    options: {
+        accounts: string[]
+    }
+    id: string
+}
+
+interface WSError {
+    error: string
+}
+
+interface WSSubscribe {
+    ack: WSAction
+    id: string
+}

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -562,7 +562,7 @@ function appendRateLimiterStatus(res: Response, data: any) {
 
 // Update current list of tracked accounts
 function updateTrackedAccounts() {
-  const confirmation_subscription = {
+  const confirmation_subscription : WSNodeMessage = {
     "action": "subscribe",
     "topic": "confirmation",
     "ack":true,
@@ -1029,6 +1029,16 @@ if (settings.use_https) {
 type WSTopic = 'confirmation'
 type WSAction = 'subscribe' | 'unsubscribe'
 
+interface WSNodeMessage {
+  action: WSAction
+  topic: WSTopic
+  ack: boolean
+  options: {
+    all_local_accounts: boolean
+    accounts: string[]
+  }
+}
+
 interface WSMessage {
   topic: WSTopic
   action: WSAction
@@ -1043,7 +1053,7 @@ interface WSError {
 }
 
 interface WSSubscribe {
-  ack: string
+  ack: WSAction
   id: string
 }
 
@@ -1256,7 +1266,7 @@ if (settings.use_websocket) {
       let tracked_accounts = tracking_db.get('users').value()
       // loop all existing tracked accounts as subscribed to by users
       tracked_accounts.forEach(async function(user) {
-        if ("tracked_accounts" in user && "ip" in user) {
+        if (user.tracked_accounts && user.ip) {
           // loop all existing accounts for that user
           for (const [key] of Object.entries(user.tracked_accounts)) {
             if (key === observed_account || key === observed_link) {

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -1026,6 +1026,27 @@ if (settings.use_https) {
   }
 }
 
+type WSTopic = 'confirmation'
+type WSAction = 'subscribe' | 'unsubscribe'
+
+interface WSMessage {
+  topic: WSTopic
+  action: WSAction
+  options: {
+    accounts: string[]
+  }
+  id: string
+}
+
+interface WSError {
+  error: string
+}
+
+interface WSSubscribe {
+  ack: string
+  id: string
+}
+
 // WEBSOCKET SERVER
 //---------------------
 if (settings.use_websocket) {
@@ -1079,70 +1100,57 @@ if (settings.use_websocket) {
     }
 
     connection.on('message', function(message: IMessage) {
-      if (message.type === 'utf8') {
+      if (message.type === 'utf8' && message.utf8Data) {
           //console.log('Received Message: ' + message.utf8Data + ' from ' + remote_ip)
           try {
-            // @ts-ignore utf8Data might be undefined AND don't know what type to expect here
-            let msg = JSON.parse(message.utf8Data)
-            // new subscription
-            if ('action' in msg && 'topic' in msg && msg.action === 'subscribe') {
-              if (msg.topic === 'confirmation') {
-                if ('options' in msg && 'accounts' in msg.options) {
-                  if (msg.options.accounts.length <= settings.websocket_max_accounts) {
-                    // check if new unique accounts + existing accounts exceed max limit
-                    // get existing tracked accounts
-                    let current_user = tracking_db.get('users').find({ip: remote_ip}).value()
-                    var current_tracked_accounts = {} //if not in db, use empty dict
-                    if (current_user !== undefined) {
-                      current_tracked_accounts = current_user.tracked_accounts
-                    }
+            let msg: WSMessage = JSON.parse(message.utf8Data)
+            if (msg.topic === 'confirmation') {
+              // New subscription
+              if (msg.action === 'subscribe' && msg.options && msg.options.accounts) {
+                {
+                  // check if new unique accounts + existing accounts exceed max limit
+                  // get existing tracked accounts
+                  let current_user = tracking_db.get('users').find({ip: remote_ip}).value()
+                  var current_tracked_accounts = {} //if not in db, use empty dict
+                  if (current_user !== undefined) {
+                    current_tracked_accounts = current_user.tracked_accounts
+                  }
 
-                    // count new accounts that are not already tracked
-                    let unique_new = 0
-                    msg.options.accounts.forEach(function(address: string) {
-                      var address_exists = false
-                      for (const [key] of Object.entries(current_tracked_accounts)) {
-                        if (key === address)  {
-                          address_exists = true
-                        }
+                  // count new accounts that are not already tracked
+                  let unique_new = 0
+                  msg.options.accounts.forEach(function (address: string) {
+                    var address_exists = false
+                    for (const [key] of Object.entries(current_tracked_accounts)) {
+                      if (key === address) {
+                        address_exists = true
                       }
-                      if (!address_exists) {
-                        unique_new++
+                    }
+                    if (!address_exists) {
+                      unique_new++
+                    }
+                  })
+                  if (unique_new + Object.keys(current_tracked_accounts).length <= settings.websocket_max_accounts) {
+                    // save connection to global dicionary to reuse when getting messages from the node websocket
+                    websocket_connections.set(remote_ip, connection)
+
+                    // mirror the subscription to the real websocket
+                    var tracking_updated = false
+                    msg.options.accounts.forEach(function (address: string) {
+                      if (trackAccount(connection, address)) {
+                        tracking_updated = true
                       }
                     })
-                    if (unique_new + Object.keys(current_tracked_accounts).length <= settings.websocket_max_accounts) {
-                      // save connection to global dicionary to reuse when getting messages from the node websocket
-                      websocket_connections.set(remote_ip, connection)
-
-                      // mirror the subscription to the real websocket
-                      var tracking_updated = false
-                      msg.options.accounts.forEach(function(address: string) {
-                        if (trackAccount(connection, address)) {
-                          tracking_updated = true
-                        }
-                      })
-                      if (tracking_updated) {
-                        updateTrackedAccounts() //update the websocket subscription
-                      }
-                      connection.sendUTF(JSON.stringify({'ack':'subscribe','id':'id' in msg ? msg.id:""}, null, 2))
+                    if (tracking_updated) {
+                      updateTrackedAccounts() //update the websocket subscription
                     }
-                    else {
-                      connection.sendUTF(JSON.stringify({'error':'Too many accounts subscribed. Max is ' + settings.websocket_max_accounts}, null, 2))
-                    }
-                  }
-                  else {
-                    connection.sendUTF(JSON.stringify({'error':'Too many accounts subscribed. Max is ' + settings.websocket_max_accounts}, null, 2))
+                    wsSend(connection, {ack: 'subscribe', id: 'id' in msg ? msg.id : ""})
+                  } else {
+                    wsSend(connection, {error: 'Too many accounts subscribed. Max is ' + settings.websocket_max_accounts})
                   }
                 }
-                else {
-                  connection.sendUTF(JSON.stringify({'error':'You must provide the accounts to track via the options parameter'}, null, 2))
-                }
-              }
-            }
-            else if ('action' in msg && 'topic' in msg && msg.action === 'unsubscribe') {
-              if (msg.topic === 'confirmation') {
+              } else if (msg.action === 'unsubscribe') {
                 logThis('User unsubscribed from confirmation: ' + remote_ip, log_levels.info)
-                tracking_db.get('users').find({ip: remote_ip}).assign({'tracked_accounts':[]}).write()
+                tracking_db.get('users').find({ip: remote_ip}).assign({'tracked_accounts': []}).write()
               }
             }
           }
@@ -1158,6 +1166,10 @@ if (settings.use_websocket) {
       websocket_connections.delete(remote_ip)
     })
   })
+}
+
+function wsSend(connection: connection, val: WSSubscribe | WSError): void {
+  connection.sendUTF(JSON.stringify(val, null, 2))
 }
 
 function originIsAllowed(origin: string) {

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -562,7 +562,7 @@ function appendRateLimiterStatus(res: Response, data: any) {
 
 // Update current list of tracked accounts
 function updateTrackedAccounts() {
-  const confirmation_subscription : WSNodeMessage = {
+  const confirmation_subscription : WSNodeSubscribe = {
     "action": "subscribe",
     "topic": "confirmation",
     "ack":true,
@@ -1029,7 +1029,7 @@ if (settings.use_https) {
 type WSTopic = 'confirmation'
 type WSAction = 'subscribe' | 'unsubscribe'
 
-interface WSNodeMessage {
+interface WSNodeSubscribe {
   action: WSAction
   topic: WSTopic
   ack: boolean
@@ -1037,6 +1037,16 @@ interface WSNodeMessage {
     all_local_accounts: boolean
     accounts: string[]
   }
+}
+interface WSNodeReceive {
+  topic: WSTopic
+  message: {
+    account: string
+    block: {
+      link_as_account: string
+    }
+  }
+  ack: WSAction
 }
 
 interface WSMessage {
@@ -1255,7 +1265,7 @@ if (settings.use_websocket) {
 
   // A tracked account was detected
   newWebSocket.onmessage = (msg: MessageEvent) => {
-    let data_json = JSON.parse(msg.data)
+    let data_json: WSNodeReceive = JSON.parse(msg.data)
 
     // Check if the tracked account belongs to a user
     if (data_json.topic === "confirmation") {
@@ -1278,10 +1288,8 @@ if (settings.use_websocket) {
         }
       })
     }
-    else if ("ack" in data_json) {
-      if (data_json.ack === "subscribe") {
-        logThis("Websocket subscription updated", log_levels.info)
-      }
+    else if (data_json.ack === "subscribe") {
+      logThis("Websocket subscription updated", log_levels.info)
     }
   }
 

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -1026,47 +1026,6 @@ if (settings.use_https) {
   }
 }
 
-type WSTopic = 'confirmation'
-type WSAction = 'subscribe' | 'unsubscribe'
-
-interface WSNodeSubscribe {
-  action: WSAction
-  topic: WSTopic
-  ack: boolean
-  options: {
-    all_local_accounts: boolean
-    accounts: string[]
-  }
-}
-interface WSNodeReceive {
-  topic: WSTopic
-  message: {
-    account: string
-    block: {
-      link_as_account: string
-    }
-  }
-  ack: WSAction
-}
-
-interface WSMessage {
-  topic: WSTopic
-  action: WSAction
-  options: {
-    accounts: string[]
-  }
-  id: string
-}
-
-interface WSError {
-  error: string
-}
-
-interface WSSubscribe {
-  ack: WSAction
-  id: string
-}
-
 // WEBSOCKET SERVER
 //---------------------
 if (settings.use_websocket) {


### PR DESCRIPTION
Adds base types for websockets. The naming of these types can perhaps be improved. And perhads `WSNodeSubscribe` and `WSMessage` should be the same type with optional `ack` and `id`?

Fixes #32 