### PR TITLE
Adds representative api

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,23 @@ Returns the latest Nano price quote from Coinpaprika. Will always be cached for 
       }
     }
 
+* **{"action":"verified_accounts"}**
+
+Returns a list of verified accounts from https://mynano.ninja/. These can be used as suggestions for representative accounts.
+This response is cached for 1 minute:
+
+    [
+      {
+        "votingweight": 7.231803912122739e+35,
+        "delegators": 1359,
+        "uptime": 99.72967712635973,
+        "score": 99,
+        "account": "nano_33ad5app7jeo6jfe9ure6zsj8yg7knt6c1zrr5yg79ktfzk5ouhmpn6p5d7p",
+        "alias": "warai"
+      },
+      ...
+    ]
+
 * **{"action":"mnano_to_raw","amount":"1"}**
 
 Converts NANO to raw

--- a/src/server/settings.json.default
+++ b/src/server/settings.json.default
@@ -59,7 +59,8 @@
     "mnano_from_raw",
     "work_validate",
     "validate_account_number",
-    "version"
+    "version",
+    "verified_accounts"
   ],
   "cached_commands":        {
     "block_count":            30,

--- a/src/server/src/__test__/proxy_file.test.ts
+++ b/src/server/src/__test__/proxy_file.test.ts
@@ -59,7 +59,8 @@ const expectedSettingsWithFile = [
     '33 : mnano_from_raw\n' +
     '34 : work_validate\n' +
     '35 : validate_account_number\n' +
-    '36 : version\n',
+    '36 : version\n' +
+    '37 : verified_accounts\n',
     'Cached commands:\n' +
     '\n' +
     'block_count : 30\n' +

--- a/src/server/src/mynano-api/mynano-api.ts
+++ b/src/server/src/mynano-api/mynano-api.ts
@@ -1,0 +1,12 @@
+/** @see https://mynano.ninja/api/accounts/verified */
+interface VerifiedAccount {
+    votingweight: number
+    delegators: number
+    uptime: number
+    score: number
+    account: string
+    alias: string
+    tokens_total?: number
+}
+
+type VerifiedAccountsResponse = VerifiedAccount[]

--- a/src/server/src/mynano-api/mynano-api.ts
+++ b/src/server/src/mynano-api/mynano-api.ts
@@ -1,12 +1,24 @@
+import {VerifiedAccount} from "../node-api/proxy-api";
+
 /** @see https://mynano.ninja/api/accounts/verified */
-interface VerifiedAccount {
+interface MynanoVerifiedAccount {
     votingweight: number
     delegators: number
     uptime: number
     score: number
     account: string
     alias: string
-    tokens_total?: number
 }
 
-type VerifiedAccountsResponse = VerifiedAccount[]
+export type MynanoVerifiedAccountsResponse = MynanoVerifiedAccount[]
+
+export const mynanoToVerifiedAccount: (a: MynanoVerifiedAccount, tokensTotal?: number) => VerifiedAccount = (verifiedAccount, tokensTotal) => {
+    return {
+        votingweight: verifiedAccount.votingweight,
+        delegators: verifiedAccount.delegators,
+        uptime: verifiedAccount.uptime,
+        score: verifiedAccount.score,
+        account: verifiedAccount.account,
+        alias: verifiedAccount.alias,
+    }
+}

--- a/src/server/src/node-api/proxy-api.ts
+++ b/src/server/src/node-api/proxy-api.ts
@@ -15,3 +15,12 @@ export interface ProxyRPCRequest {
     count: number
     hash: string
 }
+
+export interface VerifiedAccount {
+    votingweight: number
+    delegators: number
+    uptime: number
+    score: number
+    account: string
+    alias: string
+}

--- a/src/server/src/node-api/proxy-api.ts
+++ b/src/server/src/node-api/proxy-api.ts
@@ -1,6 +1,6 @@
 import {TokenAPIActions} from "./token-api";
 
-export type RPCAction = TokenAPIActions | 'mnano_to_raw' | 'mnano_from_raw' | 'process' | 'work_generate' | 'price'
+export type RPCAction = TokenAPIActions | 'mnano_to_raw' | 'mnano_from_raw' | 'process' | 'work_generate' | 'price' | 'verified_accounts'
 
 export interface ProxyRPCRequest {
     action: RPCAction

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -741,7 +741,7 @@ async function processRequest(query: ProxyRPCRequest, req: Request, res: Respons
       const cachedValue: MynanoVerifiedAccountsResponse | undefined = rpcCache?.get('verified_accounts')
       if (cachedValue && Tools.isValidJson(cachedValue)) {
         logThis("Cache requested: " + 'verified_accounts', log_levels.info)
-        return res.json(appendRateLimiterStatus(res, cachedValue.map(a => mynanoToVerifiedAccount(a))))
+        return res.json(appendRateLimiterStatus(res, cachedValue.map(mynanoToVerifiedAccount)))
       }
 
       let data: MynanoVerifiedAccountsResponse = await Tools.getData(mynano_ninja_url, API_TIMEOUT)
@@ -749,7 +749,7 @@ async function processRequest(query: ProxyRPCRequest, req: Request, res: Respons
       if (!rpcCache?.set('verified_accounts', data, 60)) {
         logThis("Failed saving cache for " + 'verified_accounts', log_levels.warning)
       }
-      return res.json(appendRateLimiterStatus(res, data.map(a => mynanoToVerifiedAccount(a))))
+      return res.json(appendRateLimiterStatus(res, data.map(mynanoToVerifiedAccount)))
     }
     catch(err) {
       return res.status(500).json({error: err.toString()})


### PR DESCRIPTION
Adds support for fetching verified accounts from mynano.ninja, the same way we do with price.

I don't quite understand why we append `data.tokens_total` onto the price response, but that's not an option here, since we return a plain javascript array. Do we need to support this? :thinking: 

Also added this with a mapper, so that it's easier to fix intermittent errors or swap out the API at some point.

Fixes #40 