### PR TITLE
Allow token key in request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@ Any RPC command can be made by including a request key. For each request 1 token
       "tokens_total": 4999
     }
 
+As an alternative, it's also valid to include the token key via the header "Token: xyz".
+
+    curl -H "Token: 815c8c736756da0965ca0994e9ac59a0da7f635aa0675184eff96a3146c49d74" -d '{"action":"block_count"}' http://127.0.0.1:9950/proxy
+
 * **{"action":"tokens_buy","token_amount":10}**
 
 Initiates a new order of 10 tokens and respond with a deposit account, a token key and the amount of Nano to pay

--- a/src/server/src/__test__/process_request.test.ts
+++ b/src/server/src/__test__/process_request.test.ts
@@ -28,7 +28,9 @@ test('processRequest should fail at unreachable node', async () => {
     let body = {
         action: 'block_info'
     }
-    let request: any = {}
+    let request: any = {
+        get: (name: string) => undefined
+    }
     let mockResponse: MockResponse = new MockResponse()
 
     await proxy.processRequest(body, request, mockResponse)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -691,7 +691,12 @@ async function processRequest(query: ProxyRPCRequest, req: Request, res: Respons
 
   // Decrease user tokens and block if zero left
   var tokens_left: number | null = null
+  var token_header: string | undefined = req.get('Token')
   if (settings.use_tokens) {
+    // If token supplied via header, use it instead
+    if (token_header) {
+      query.token_key = token_header
+    }
     if (query.token_key) {
       let status = useToken(query)
       if (status === -1) {


### PR DESCRIPTION
As a complement to give the token key in the post data, allow it also in the header.
Fixes #33 

The "Authorization" key is already used by the credential-system so that can't be used. Which means incompatibility with https://mynano.ninja/api/node

Instead, the key "Token" is used.

`curl -H "Token: 45565ecd5c261ce170834cf01120fc4af83ba16e01cb446b24042df970d0f31" -d '{\"action\":\"block_count\"}' 127.0.0.1:9950/proxy `