### PR TITLE
Adds proposal for Prometheus metrics

### DIFF
--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -1572,6 +1572,11 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
       "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
@@ -5772,6 +5777,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "prom-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.0.0.tgz",
+      "integrity": "sha512-M7ZNjIO6x+2R/vjSD13yjJPjpoZA8eEwH2Bp2Re0/PvzozD7azikv+SaBtZes4Q1ca/xHjZ4RSCuTag3YZLg1A==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -6993,6 +7006,14 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
     },
     "terminal-link": {
       "version": "2.1.1",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -34,6 +34,7 @@
     "node-fetch": "^2.6.1",
     "node-schedule": "^1.3.2",
     "package.json": "^2.0.1",
+    "prom-client": "^13.0.0",
     "pug": "^2.0.4",
     "rate-limiter-flexible": "^2.1.4",
     "reconnecting-websocket": "^4.4.0",

--- a/src/server/settings.json.default
+++ b/src/server/settings.json.default
@@ -22,6 +22,7 @@
   "use_dpow":               false,
   "use_bpow":               false,
   "disable_watch_work":     false,
+  "enable_prometheus":      false,
   "allowed_commands":       [
     "account_history",
     "account_info",

--- a/src/server/settings.json.default
+++ b/src/server/settings.json.default
@@ -23,6 +23,7 @@
   "use_bpow":               false,
   "disable_watch_work":     false,
   "enable_prometheus":      false,
+  "prometheus_ip_whitelist": [],
   "allowed_commands":       [
     "account_history",
     "account_info",

--- a/src/server/settings.json.default
+++ b/src/server/settings.json.default
@@ -22,8 +22,7 @@
   "use_dpow":               false,
   "use_bpow":               false,
   "disable_watch_work":     false,
-  "enable_prometheus":      false,
-  "prometheus_ip_whitelist": [],
+  "enable_prometheus_for_ips": [],
   "allowed_commands":       [
     "account_history",
     "account_info",

--- a/src/server/src/prom-client.ts
+++ b/src/server/src/prom-client.ts
@@ -24,7 +24,7 @@ export function createPrometheusClient(): PromClient {
     let processRequestCounter = new client.Counter({
         registers: [register],
         name: "processRequest",
-        help: "Counts processRequest per IP address",
+        help: "Counts processRequest per IP address and action",
         labelNames: ["action", "ip"]
     })
 
@@ -38,14 +38,14 @@ export function createPrometheusClient(): PromClient {
     let countRateLimited = new client.Counter({
         registers: [register],
         name: "user_ratelimited",
-        help: "Incremented a client is rate limited",
+        help: "Counts number of times an IP address is rate limited",
         labelNames: ["ip"]
     })
 
     let rpcHistogram = new client.Histogram({
         registers: [register],
         name: "time_rpc_call",
-        help: "Times the RPC calls to the Nano node",
+        help: "Times RPC calls to the Nano backend",
         labelNames: ["action"]
     })
 

--- a/src/server/src/prom-client.ts
+++ b/src/server/src/prom-client.ts
@@ -23,7 +23,7 @@ export function createPrometheusClient(): PromClient {
 
     let processRequestCounter = new client.Counter({
         registers: [register],
-        name: "processRequest",
+        name: "process_request",
         help: "Counts processRequest per IP address and action",
         labelNames: ["action", "ip"]
     })
@@ -37,7 +37,7 @@ export function createPrometheusClient(): PromClient {
 
     let countRateLimited = new client.Counter({
         registers: [register],
-        name: "user_ratelimited",
+        name: "user_rate_limited",
         help: "Counts number of times an IP address is rate limited",
         labelNames: ["ip"]
     })

--- a/src/server/src/prom-client.ts
+++ b/src/server/src/prom-client.ts
@@ -1,0 +1,45 @@
+import client, {LabelValues} from "prom-client";
+import {RPCAction} from "./node-api/proxy-api";
+import {LogLevel} from "./common-settings";
+
+export interface PromClient {
+    metrics(): Promise<string>
+    incRequest: (action: RPCAction, ip: string) => void
+    incLogging: (logLevel: LogLevel) => void
+    timeNodeRpc: (action: RPCAction) => (labels?: LabelValues<any>) => number
+}
+
+export function createPrometheusClient(): PromClient {
+    const collectDefaultMetrics = client.collectDefaultMetrics;
+    const Registry = client.Registry;
+    const register = new Registry();
+    collectDefaultMetrics({ register });
+
+    let processRequestCounter = new client.Counter({
+        registers: [register],
+        name: "processRequest",
+        help: "Counts processRequest per IP address",
+        labelNames: ["action", "ip"]
+    })
+
+    let logCounter = new client.Counter({
+        registers: [register],
+        name: "log",
+        help: "Counts number of logged events",
+        labelNames: ["log_level"]
+    })
+
+    let rpcHistogram = new client.Histogram({
+        registers: [register],
+        name: "rpcRequestTime",
+        help: "Times the RPC calls to the Nano node",
+        labelNames: ["action"]
+    })
+
+    return {
+        metrics: async () => register.metrics(),
+        incRequest: (action: RPCAction, ip: string) => processRequestCounter.labels(action, ip).inc(),
+        incLogging: (logLevel: LogLevel) => logCounter.labels(logLevel).inc(),
+        timeNodeRpc: (action: RPCAction) => rpcHistogram.startTimer({action: action})
+    }
+}

--- a/src/server/src/prom-client.ts
+++ b/src/server/src/prom-client.ts
@@ -6,7 +6,8 @@ export interface PromClient {
     metrics(): Promise<string>
     incRequest: (action: RPCAction, ip: string) => void
     incLogging: (logLevel: LogLevel) => void
-    timeNodeRpc: (action: RPCAction) => (labels?: LabelValues<any>) => number
+    timeNodeRpc: (action: RPCAction) => (labels?: LabelValues<any>) => number,
+    path: string
 }
 
 export function createPrometheusClient(): PromClient {
@@ -40,6 +41,7 @@ export function createPrometheusClient(): PromClient {
         metrics: async () => register.metrics(),
         incRequest: (action: RPCAction, ip: string) => processRequestCounter.labels(action, ip).inc(),
         incLogging: (logLevel: LogLevel) => logCounter.labels(logLevel).inc(),
-        timeNodeRpc: (action: RPCAction) => rpcHistogram.startTimer({action: action})
+        timeNodeRpc: (action: RPCAction) => rpcHistogram.startTimer({action: action}),
+        path: '/prometheus'
     }
 }

--- a/src/server/src/proxy-settings.ts
+++ b/src/server/src/proxy-settings.ts
@@ -97,4 +97,6 @@ export default interface ProxySettings {
     disable_watch_work: boolean;
     // Enables prometheus metrics
     enable_prometheus: boolean;
+    // IP addresses to whitelist prometheus for. Typically '127.0.0.1', or '::ffff:127.0.0.1' for IPv6
+    prometheus_ip_whitelist: string[];
 }

--- a/src/server/src/proxy-settings.ts
+++ b/src/server/src/proxy-settings.ts
@@ -95,4 +95,6 @@ export default interface ProxySettings {
     log_level: LogLevel;
     // forcefully set watch_work=false for process calls (to block node from doing rework)
     disable_watch_work: boolean;
+    // Enables prometheus metrics
+    enable_prometheus: boolean;
 }

--- a/src/server/src/proxy-settings.ts
+++ b/src/server/src/proxy-settings.ts
@@ -95,8 +95,6 @@ export default interface ProxySettings {
     log_level: LogLevel;
     // forcefully set watch_work=false for process calls (to block node from doing rework)
     disable_watch_work: boolean;
-    // Enables prometheus metrics
-    enable_prometheus: boolean;
-    // IP addresses to whitelist prometheus for. Typically '127.0.0.1', or '::ffff:127.0.0.1' for IPv6
-    prometheus_ip_whitelist: string[];
+    // IP addresses to enable prometheus for. Typically '127.0.0.1', or '::ffff:127.0.0.1' for IPv6
+    enable_prometheus_for_ips: string[];
 }

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -617,10 +617,12 @@ if (settings.request_path != '/') {
 
 if(promClient) {
   app.get(promClient.path, async (req: Request, res: Response) => {
-    if(req.connection.remoteAddress && settings.enable_prometheus_for_ips.includes(req.connection.remoteAddress)) {
+    const remoteAddress: string | undefined = req.connection.remoteAddress;
+    if(remoteAddress && settings.enable_prometheus_for_ips.includes(remoteAddress)) {
       let metrics = await promClient.metrics();
       res.set('content-type', 'text/plain').send(metrics)
     } else {
+      logThis(`Prometheus not enabled for ${remoteAddress}`, log_levels.info)
       res.status(403).send()
     }
   })

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -956,7 +956,7 @@ async function processRequest(query: ProxyRPCRequest, req: Request, res: Respons
   }
 
   // Send the request to the Nano node and return the response
-  let endNodeTimer = promClient ? promClient.timeNodeRpc(query.action) : undefined
+  let endNodeTimer = promClient?.timeNodeRpc(query.action)
   try {
     let data: ProcessDataResponse = await Tools.postData(query, settings.node_url, API_TIMEOUT)
     // Save cache if applicable

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -433,6 +433,7 @@ if (settings.use_rate_limiter) {
         next()
       })
       .catch((rej: any) => {
+        promClient?.incRateLimited(req.ip)
         res.set("X-RateLimit-Limit", settings.rate_limiter.request_limit)
         res.set("X-RateLimit-Remaining", `${Math.max(settings.rate_limiter.request_limit-rej.consumedPoints, 0)}`)
         res.set("X-RateLimit-Reset", `${new Date(Date.now() + rej.msBeforeNext)}`)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -389,6 +389,9 @@ if (settings.use_rate_limiter) {
   })
 
   const rateLimiterMiddleware1 = (req: Request, res: Response, next: (err?: any) => any) => {
+    if(promClient && req.path === promClient.path) {
+      return
+    }
     if (settings.use_tokens) {
       // Check if token key exist in DB and have enough tokens, then skip IP block by returning true
       if ('token_key' in req.body && order_db.get('orders').find({token_key: req.body.token_key}).value()) {
@@ -606,7 +609,7 @@ if (settings.request_path != '/') {
 }
 
 if(promClient) {
-  app.get('/prometheus', async (req: Request, res: Response) => {
+  app.get(promClient.path, async (req: Request, res: Response) => {
     let metrics = await promClient.metrics();
     res.set('content-type', 'text/plain').send(metrics)
   })

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -611,7 +611,7 @@ if (settings.request_path != '/') {
 
 if(promClient) {
   app.get(promClient.path, async (req: Request, res: Response) => {
-    let isLocal = (req.connection.localAddress === req.connection.remoteAddress);
+    const isLocal = (req.connection.localAddress === req.connection.remoteAddress);
     if(isLocal) {
       let metrics = await promClient.metrics();
       res.set('content-type', 'text/plain').send(metrics)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -390,6 +390,7 @@ if (settings.use_rate_limiter) {
 
   const rateLimiterMiddleware1 = (req: Request, res: Response, next: (err?: any) => any) => {
     if(promClient && req.path === promClient.path) {
+      next();
       return
     }
     if (settings.use_tokens) {
@@ -610,8 +611,13 @@ if (settings.request_path != '/') {
 
 if(promClient) {
   app.get(promClient.path, async (req: Request, res: Response) => {
-    let metrics = await promClient.metrics();
-    res.set('content-type', 'text/plain').send(metrics)
+    let isLocal = (req.connection.localAddress === req.connection.remoteAddress);
+    if(isLocal) {
+      let metrics = await promClient.metrics();
+      res.set('content-type', 'text/plain').send(metrics)
+    } else {
+      res.status(403)
+    }
   })
 }
 

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -23,7 +23,6 @@ import {multiplierFromDifficulty} from "./tools";
 import {MynanoVerifiedAccountsResponse, mynanoToVerifiedAccount} from "./mynano-api/mynano-api";
 import process from 'process'
 import {createPrometheusClient, MaybeTimedCall, PromClient} from "./prom-client";
-import {LabelValues} from "prom-client";
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -616,7 +616,7 @@ if(promClient) {
       let metrics = await promClient.metrics();
       res.set('content-type', 'text/plain').send(metrics)
     } else {
-      res.status(403)
+      res.status(403).send()
     }
   })
 }


### PR DESCRIPTION
As mentioned in #46, adds initial support of Prometheus metrics. These metrics must then either be pushed, or as in this case be scraped from the endpoint  `/prometheus`. This PR is merely to show what is possible, and only exposes a few of the metrics. 

One must-fix if we decide to progress with this is to ensure `/prometheus` endpoint is "protected" somehow (at least if exposing anything like IP adresses).

A method of testing this can be to add this to the docker-compose-file (the proxy exposes metrics → prometheus scrapes metrics → grafana displays metrics):

```
nanorpcproxy:
....docker-compose-things

prometheus:
  image: prom/prometheus
  volumes:
    - /path/to/prometheus.yml:/etc/prometheus/prometheus.yml
  ports:
    - 9090:9090

grafana:
  image: grafana/grafana
  depends_on:
    - prometheus
  ports:
    - 3000:3000
  user: "472"
```

And make the `prometheus.yml` point to the Nano RPC proxy prometheus endpoint like this:

```
global:
  scrape_interval: 30s
  scrape_timeout: 10s
  
scrape_configs:
  - job_name: services
    metrics_path: /prometheus
    static_configs:
      - targets:
          - 'nanorpcproxy:9950'
```
When setting up `Prometheus` as datasource in Grafana, you would then get live metrics like this:

![Screenshot_2021-01-21_19-57-30](https://user-images.githubusercontent.com/788059/105403662-4ff80180-5c29-11eb-922b-6a8a00b34805.png)
