### PR TITLE
Use network_receive_current

### DIFF
--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -708,7 +708,7 @@ async function getOrFetchDifficulty(): Promise<ActiveDifficultyResponse | undefi
     const difficultyResponse = await Tools.postData<ActiveDifficultyResponse>({"action":"active_difficulty"}, settings.node_url, API_TIMEOUT)
     const saved = rpcCache?.set('active_difficulty', difficultyResponse, 60)
     if(saved) {
-      logThis("New active_difficulty: " + difficultyResponse, log_levels.info)
+      logThis("New active_difficulty: " + JSON.stringify(difficultyResponse), log_levels.info)
       return difficultyResponse
     } else {
       logThis("Failed saving cache for " + 'active_difficulty', log_levels.warning)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -708,7 +708,6 @@ async function getOrFetchDifficulty(): Promise<ActiveDifficultyResponse | undefi
     const difficultyResponse = await Tools.postData<ActiveDifficultyResponse>({"action":"active_difficulty"}, settings.node_url, API_TIMEOUT)
     const saved = rpcCache?.set('active_difficulty', difficultyResponse, 60)
     if(saved) {
-      logThis("New active_difficulty: " + JSON.stringify(difficultyResponse), log_levels.info)
       return difficultyResponse
     } else {
       logThis("Failed saving cache for " + 'active_difficulty', log_levels.warning)

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -674,6 +674,49 @@ async function processTokensRequest(query: ProxyRPCRequest, req: Request, res: R
   }
 }
 
+async function getLatestDifficulty(difficulty: string | undefined) {
+  const activeDifficulty: ActiveDifficultyResponse | undefined = await getOrFetchDifficulty()
+  // Receive-block difficulty
+  if(difficulty === work_threshold_receive_default) {
+    if(activeDifficulty?.network_receive_current) {
+      logThis("Using new difficulty for receive: " + activeDifficulty.network_receive_current, log_levels.info)
+      return activeDifficulty.network_receive_current;
+    } else {
+      logThis("Using default difficulty for receive: " + work_threshold_receive_default, log_levels.info)
+      return work_threshold_receive_default
+    }
+  }
+  // Send-block difficulty if default or not specified
+  else {
+    if(activeDifficulty?.network_current) {
+      logThis("Using new difficulty: " + activeDifficulty.network_current, log_levels.info)
+      return activeDifficulty.network_current;
+    } else {
+      logThis("Using default difficulty: " + work_threshold_default, log_levels.info)
+      return work_threshold_default
+    }
+  }
+}
+
+/** Returns `active_difficulty` from cache, or fetches from network */
+async function getOrFetchDifficulty(): Promise<ActiveDifficultyResponse | undefined> {
+  const difficultyFromCache: ActiveDifficultyResponse | undefined = rpcCache?.get<ActiveDifficultyResponse>('active_difficulty')
+  if(difficultyFromCache) {
+    logThis("Cache requested: " + 'active_difficulty', log_levels.info)
+    return difficultyFromCache
+  } else {
+    const difficultyResponse = await Tools.postData<ActiveDifficultyResponse>({"action":"active_difficulty"}, settings.node_url, API_TIMEOUT)
+    const saved = rpcCache?.set('active_difficulty', difficultyResponse, 60)
+    if(saved) {
+      logThis("New active_difficulty: " + difficultyResponse, log_levels.info)
+      return difficultyResponse
+    } else {
+      logThis("Failed saving cache for " + 'active_difficulty', log_levels.warning)
+      return undefined
+    }
+  }
+}
+
 async function processRequest(query: ProxyRPCRequest, req: Request, res: Response<ProcessResponse | TokenAPIResponses>): Promise<Response> {
   if (query.action !== 'tokenorder_check') {
     logThis('RPC request received from ' + req.ip + ': ' + query.action, log_levels.info)
@@ -798,55 +841,7 @@ async function processRequest(query: ProxyRPCRequest, req: Request, res: Respons
       var bpow_failed = false
       // Only set difficulty from live network if not requested or if it was exactly default
       if (!query.difficulty || query.difficulty === work_threshold_default || query.difficulty === work_threshold_receive_default) {
-        // Use cached value first
-        let cachedValue: string | undefined
-        // Receive-difficulty
-        if (query.difficulty === work_threshold_receive_default) {
-          cachedValue = rpcCache?.get<string>('difficulty_receive')
-        }
-        // Default send-difficulty or not specified
-        else {
-          cachedValue = rpcCache?.get<string>('difficulty')
-        }
-
-        if (Tools.isValidJson(cachedValue)) {
-          logThis("Cache requested: " + 'difficulty', log_levels.info)
-          query.difficulty = cachedValue
-        }
-        else {
-          // Get latest difficulty from network
-          let data: ActiveDifficultyResponse = await Tools.postData({"action":"active_difficulty"}, settings.node_url, API_TIMEOUT)
-          // Send-block difficulty if default or not specified
-          if (!query.difficulty || query.difficulty === work_threshold_default) {
-            if (data.network_current) {
-              // Store the difficulty in cache for 60sec
-              if (!rpcCache?.set('difficulty', data.network_current, 60)) {
-                logThis("Failed saving cache for " + 'difficulty', log_levels.warning)
-              }
-              query.difficulty = data.network_current
-              logThis("New difficulty: " + query.difficulty, log_levels.info)
-            }
-            else {
-              query.difficulty = work_threshold_default
-              logThis("Using default difficulty: " + query.difficulty, log_levels.info)
-            }
-          }
-          // Receive-block difficulty
-          else if (query.difficulty === work_threshold_receive_default) {
-            if (data.network_receive_current) {
-              // Store the difficulty in cache for 60sec
-              if (!rpcCache?.set('difficulty_receive', data.network_receive_current, 60)) {
-                logThis("Failed saving cache for " + 'difficulty_receive', log_levels.warning)
-              }
-              query.difficulty = data.network_receive_current
-              logThis("New difficulty receive: " + query.difficulty, log_levels.info)
-            }
-            else {
-              query.difficulty = work_threshold_receive_default
-              logThis("Using default difficulty for receive: " + query.difficulty, log_levels.info)
-            }
-          }
-        }
+        query.difficulty = await getLatestDifficulty(query.difficulty)
       }
 
       if (!(query.timeout)) {

--- a/src/server/src/tools.ts
+++ b/src/server/src/tools.ts
@@ -109,16 +109,6 @@ function isNumeric(val: string): boolean {
   }
 }
 
-// Compare two hex strings, returns 0 if equal, -1 if A<B and 1 if A>B
-export function compareHex(a: string | number, b: string | number): number {
-  a = parseInt('0x' + a, 16)
-  b = parseInt('0x' + b, 16)
-  let result = 0
-  if (a > b) result = 1
-  else if(a < b) result = -1
-  return result
-}
-
 // Determine new multiplier from base difficulty (hexadecimal string) and target difficulty (hexadecimal string). Returns float
 export function multiplierFromDifficulty(difficulty: string, base_difficulty: string): string {
   let big64 = Dec.BigDecimal(2).pow(64)


### PR DESCRIPTION
If requesting default receive difficulty
The logic for default send difficulty was already implemented in the previous commit

The new behaviour will be
* Request send default: Check network_current and override
* Request send a little bit more than default: Use that value
* Request receive default 1/64x: Check network_receive_current and override
* Request receive a little bit more: Use that value