### PR TITLE
Ip subnet whitelist

### DIFF
--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -3245,6 +3245,14 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "ip-range-check": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+      "integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+      "requires": {
+        "ipaddr.js": "^1.0.1"
+      }
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -27,6 +27,7 @@
     "helmet": "^3.23.0",
     "http": "0.0.0",
     "https": "^1.0.0",
+    "ip-range-check": "^0.2.0",
     "lowdb": "^1.0.0",
     "nanocurrency": "^2.4.0",
     "nanocurrency-web": "^1.0.6",

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -23,6 +23,7 @@ import {multiplierFromDifficulty} from "./tools";
 import {MynanoVerifiedAccountsResponse, mynanoToVerifiedAccount} from "./mynano-api/mynano-api";
 import process from 'process'
 import {createPrometheusClient, MaybeTimedCall, PromClient} from "./prom-client";
+import ipRangeCheck from "ip-range-check"
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -495,7 +496,7 @@ if (settings.request_path != '/') {
 if(promClient) {
   app.get(promClient.path, async (req: Request, res: Response) => {
     const remoteAddress: string | undefined = req.connection.remoteAddress;
-    if(remoteAddress && settings.enable_prometheus_for_ips.includes(remoteAddress)) {
+    if(remoteAddress && ipRangeCheck(remoteAddress, settings.enable_prometheus_for_ips)) {
       let metrics = await promClient.metrics();
       res.set('content-type', 'text/plain').send(metrics)
     } else {


### PR DESCRIPTION
Support for sub ranges white list. For example `"enable_prometheus_for_ips": ["172.17.0.0/16"]` to open up for docker network. Fixes #59 