### PR TITLE
Removes HTTPS server warn log, expands key/cert logging

### DIFF
--- a/src/server/src/http.ts
+++ b/src/server/src/http.ts
@@ -18,8 +18,8 @@ export function readHttpsOptions(settings: ProxySettings): https.ServerOptions |
             key: Fs.readFileSync(settings.https_key)
         }
     } catch(err) {
-        console.log("Warning: Problem reading https cert/key file!")
-        console.log(err)
+        console.error("Problem reading https cert/key file. Will not be able to create HTTPS server.")
+        console.error(err)
         return undefined
     }
 }

--- a/src/server/src/proxy.ts
+++ b/src/server/src/proxy.ts
@@ -834,17 +834,14 @@ process.on('SIGINT', () => {
   process.exit(0)
 })
 
-const httpsOptions: https.ServerOptions | undefined = settings.use_https ? readHttpsOptions(settings) : undefined;
-
 // Create an HTTP service
 if (settings.use_http && test_override_http) {
   createHttpServer(app, settings.http_port)
 }
+const httpsOptions: https.ServerOptions | undefined = settings.use_https ? readHttpsOptions(settings) : undefined;
 // Create an HTTPS service
 if (settings.use_https && httpsOptions) {
   createHttpsServer(app, settings.https_port, httpsOptions)
-} else {
-  console.log("Warning: Will not listen on https!")
 }
 
 let websocket_servers: (http.Server | https.Server)[] = []


### PR DESCRIPTION
Leftover "warning" log should not be logging out. Expands the key/cert log a bit.

Fixes #65 