### PR TITLE
Explicitly enables basic auth for request_path

### DIFF
--- a/src/server/src/authorize-user.ts
+++ b/src/server/src/authorize-user.ts
@@ -11,6 +11,12 @@ function validUser({user, password}: Credentials, suppliedUsername: string, supp
     return BasicAuth.safeCompare(suppliedUsername, user) && BasicAuth.safeCompare(suppliedPassword, password)
 }
 
+/** Accepts all requests */
+export const acceptingAuthorizer: ProxyAuthorizer = {
+    getUserSettings: (username, password) => undefined,
+    myAuthorizer: (username, password) => true
+}
+
 export function createProxyAuthorizer(defaultSettings: UserSettings, userSettings: UserSettingsConfig, users: Credentials[]): ProxyAuthorizer {
 
     const findValidUserSettings = (username: string, password: string): UserSettings | undefined => {


### PR DESCRIPTION
Adds an accepting authorizer if enable_auth is false. Sets basic auth handler specifically for the `request_path` (/proxy) path. Is it correct that there's no authentication for websockets?

Fixes #66 