### PR TITLE
Only adds basic auth handler if we're setting use_auth: true

### DIFF
--- a/src/server/src/authorize-user.ts
+++ b/src/server/src/authorize-user.ts
@@ -11,12 +11,6 @@ function validUser({user, password}: Credentials, suppliedUsername: string, supp
     return BasicAuth.safeCompare(suppliedUsername, user) && BasicAuth.safeCompare(suppliedPassword, password)
 }
 
-/** Accepts all requests */
-export const acceptingAuthorizer: ProxyAuthorizer = {
-    getUserSettings: (username, password) => undefined,
-    myAuthorizer: (username, password) => true
-}
-
 export function createProxyAuthorizer(defaultSettings: UserSettings, userSettings: UserSettingsConfig, users: Credentials[]): ProxyAuthorizer {
 
     const findValidUserSettings = (username: string, password: string): UserSettings | undefined => {


### PR DESCRIPTION
Will now constrauct a `userAuthorizer` if use_auth is set to true. Given a `userAuthorizer` it will add a basic auth handler for get/post requests.

Fixes #71 