### PR TITLE
Import fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,6 +1144,15 @@
         "@types/node": "*"
       }
     },
+    "@types/ws": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,6 +1067,15 @@
         }
       }
     },
+    "@types/node-schedule": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node-schedule/-/node-schedule-1.3.1.tgz",
+      "integrity": "sha512-xAY/ZATrThUkMElSDfOk+5uXprCrV6c6GQ5gTw3U04qPS6NofE1dhOUW+yrOF2UyrUiAax/Zc4WtagrbPAN3Tw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,6 +930,15 @@
         "@types/node": "*"
       }
     },
+    "@types/console-stamp": {
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@types/console-stamp/-/console-stamp-0.2.33.tgz",
+      "integrity": "sha512-ISAh9MXEnmW8eP6C0ItiMJX/cqqgUfom9W8XUwk9Ze51PRA01a9J3daWAUL1wDIVDovi7nD/AC6Efj2nJH6JdA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,11 +1569,6 @@
         "type-is": "~1.6.17"
       }
     },
-    "bowser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
-      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1664,11 +1659,6 @@
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
       }
-    },
-    "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -1824,11 +1814,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "content-security-policy-builder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
-      "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ=="
-    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -1962,11 +1947,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "dasherize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -2129,11 +2109,6 @@
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
-    "dns-prefetch-control": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz",
-      "integrity": "sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q=="
-    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2150,11 +2125,6 @@
           "dev": true
         }
       }
-    },
-    "dont-sniff-mimetype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
-      "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
     },
     "dotenv": {
       "version": "8.2.0",
@@ -2402,11 +2372,6 @@
         }
       }
     },
-    "expect-ct": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
-      "integrity": "sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g=="
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2623,11 +2588,6 @@
         "bser": "2.1.1"
       }
     },
-    "feature-policy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
-      "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2702,11 +2662,6 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
-    },
-    "frameguard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
-      "integrity": "sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -2990,79 +2945,14 @@
       }
     },
     "helmet": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.0.tgz",
-      "integrity": "sha512-/AKPymGd+mJsFN43IkX+nf8J11V51bxLNYReQZmWrVx7M/FEOs2OEE6U1YIt8Y00rpOupbIeVWv5woEGja1Pug==",
-      "requires": {
-        "depd": "2.0.0",
-        "dns-prefetch-control": "0.2.0",
-        "dont-sniff-mimetype": "1.1.0",
-        "expect-ct": "0.2.0",
-        "feature-policy": "0.3.0",
-        "frameguard": "3.1.0",
-        "helmet-crossdomain": "0.4.0",
-        "helmet-csp": "2.10.0",
-        "hide-powered-by": "1.1.0",
-        "hpkp": "2.0.0",
-        "hsts": "2.2.0",
-        "ienoopen": "1.1.0",
-        "nocache": "2.1.0",
-        "referrer-policy": "1.2.0",
-        "x-xss-protection": "1.3.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
-    },
-    "helmet-crossdomain": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
-      "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
-    },
-    "helmet-csp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.10.0.tgz",
-      "integrity": "sha512-Rz953ZNEFk8sT2XvewXkYN0Ho4GEZdjAZy4stjiEQV3eN7GDxg1QKmYggH7otDyIA7uGA6XnUMVSgeJwbR5X+w==",
-      "requires": {
-        "bowser": "2.9.0",
-        "camelize": "1.0.0",
-        "content-security-policy-builder": "2.1.0",
-        "dasherize": "2.0.0"
-      }
-    },
-    "hide-powered-by": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
-      "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.4.1.tgz",
+      "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
-    },
-    "hpkp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-    },
-    "hsts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-      "requires": {
-        "depd": "2.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -3125,11 +3015,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "ienoopen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
-      "integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
     },
     "import-local": {
       "version": "3.0.2",
@@ -5165,11 +5050,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "nocache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
-      "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
-    },
     "node-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.0.tgz",
@@ -5856,11 +5736,6 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
-    },
-    "referrer-policy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
-      "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7393,11 +7268,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
       "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
-    },
-    "x-xss-protection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
-      "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express-ipfilter": "^1.1.2",
     "express-slow-down": "^1.4.0",
     "fs": "0.0.1-security",
-    "helmet": "^3.23.0",
+    "helmet": "^4.1.1",
     "http": "0.0.0",
     "https": "^1.0.0",
     "ip-range-check": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -52,11 +52,12 @@
     "@types/node": "^14.14.14",
     "@types/node-fetch": "^2.5.7",
     "@types/node-schedule": "^1.3.1",
-    "@types/websocket": "^1.0.1",
     "@types/supertest": "^2.0.10",
+    "@types/websocket": "^1.0.1",
+    "@types/ws": "^7.4.0",
     "jest": "^26.6.3",
+    "supertest": "^6.1.3",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3",
-    "supertest": "^6.1.3"
+    "typescript": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ws": "^7.3.0"
   },
   "devDependencies": {
+    "@types/console-stamp": "^0.2.33",
     "@types/cors": "^2.8.9",
     "@types/express": "^4.17.9",
     "@types/express-slow-down": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/lowdb": "^1.0.9",
     "@types/node": "^14.14.14",
     "@types/node-fetch": "^2.5.7",
+    "@types/node-schedule": "^1.3.1",
     "@types/websocket": "^1.0.1",
     "@types/supertest": "^2.0.10",
     "jest": "^26.6.3",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,6 +29,7 @@ import * as https from "https";
 import {createProxyAuthorizer, ProxyAuthorizer} from "./authorize-user";
 import ipRangeCheck from "ip-range-check"
 import BasicAuth from 'express-basic-auth'
+import * as Fs from 'fs'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -36,7 +37,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const Fs =                    require('fs')
 const Express =               require('express')
 const Cors =                  require('cors')
 const IpFilter =              require('express-ipfilter').IpFilter
@@ -81,7 +81,7 @@ let rpcCount: number = 0
 let logdata: LogData[] = []
 try {
   // read latest count from file
-  logdata = JSON.parse(Fs.readFileSync(configPaths.request_stat, 'UTF-8'))
+  logdata = JSON.parse(Fs.readFileSync(configPaths.request_stat, 'utf-8'))
   rpcCount = logdata[logdata.length - 1].count
 }
 catch(e) {
@@ -105,7 +105,7 @@ Schedule.scheduleJob('0 0 * * *', () => {
   rpcCount = 0
   // update latest logdata from file
   try {
-    logdata = JSON.parse(Fs.readFileSync(configPaths.request_stat, 'UTF-8'))
+    logdata = JSON.parse(Fs.readFileSync(configPaths.request_stat, 'utf-8'))
   }
   catch(e) {
     console.log(`Could not read ${configPaths.request_stat}`, e)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,6 +28,7 @@ import * as http from "http";
 import * as https from "https";
 import {createProxyAuthorizer, ProxyAuthorizer} from "./authorize-user";
 import ipRangeCheck from "ip-range-check"
+import BasicAuth from 'express-basic-auth'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -35,7 +36,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const BasicAuth =             require('express-basic-auth')
 const Fs =                    require('fs')
 const Express =               require('express')
 const Cors =                  require('cors')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -33,6 +33,7 @@ import * as Fs from 'fs'
 import Express from 'express'
 import Cors from 'cors'
 import { IpFilter } from 'express-ipfilter'
+import { IpDeniedError } from 'express-ipfilter'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -40,7 +41,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const IpDeniedError =         require('express-ipfilter').IpDeniedError
 const Schedule =              require('node-schedule')
 const WebSocketServer =       require('websocket').server
 const WS =                    require('ws')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -31,6 +31,7 @@ import ipRangeCheck from "ip-range-check"
 import BasicAuth from 'express-basic-auth'
 import * as Fs from 'fs'
 import Express from 'express'
+import Cors from 'cors'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -38,7 +39,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const Cors =                  require('cors')
 const IpFilter =              require('express-ipfilter').IpFilter
 const IpDeniedError =         require('express-ipfilter').IpDeniedError
 const Schedule =              require('node-schedule')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,6 +30,7 @@ import {createProxyAuthorizer, ProxyAuthorizer} from "./authorize-user";
 import ipRangeCheck from "ip-range-check"
 import BasicAuth from 'express-basic-auth'
 import * as Fs from 'fs'
+import Express from 'express'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -37,7 +38,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const Express =               require('express')
 const Cors =                  require('cors')
 const IpFilter =              require('express-ipfilter').IpFilter
 const IpDeniedError =         require('express-ipfilter').IpDeniedError

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,6 +35,7 @@ import Cors from 'cors'
 import { IpFilter } from 'express-ipfilter'
 import { IpDeniedError } from 'express-ipfilter'
 import { scheduleJob } from 'node-schedule'
+import WebSocketServer from 'websocket'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -42,7 +43,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const WebSocketServer =       require('websocket').server
 const WS =                    require('ws')
 const Helmet =                require('helmet')
 const RemoveTrailingZeros =   require('remove-trailing-zeros')
@@ -861,7 +861,7 @@ if(settings.use_websocket) {
 // WEBSOCKET SERVER
 //---------------------
 if (settings.use_websocket) {
-  let wsServer: WSServer = new WebSocketServer({
+  let wsServer: WSServer = new WebSocketServer.server({
     httpServer: websocket_servers,
     autoAcceptConnections: false
   })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,6 +32,7 @@ import BasicAuth from 'express-basic-auth'
 import * as Fs from 'fs'
 import Express from 'express'
 import Cors from 'cors'
+import { IpFilter } from 'express-ipfilter'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -39,7 +40,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const IpFilter =              require('express-ipfilter').IpFilter
 const IpDeniedError =         require('express-ipfilter').IpDeniedError
 const Schedule =              require('node-schedule')
 const WebSocketServer =       require('websocket').server

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,6 +37,7 @@ import { IpDeniedError } from 'express-ipfilter'
 import { scheduleJob } from 'node-schedule'
 import WebSocketServer from 'websocket'
 import WS from 'ws'
+import Helmet from 'helmet'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -44,7 +45,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const Helmet =                require('helmet')
 const RemoveTrailingZeros =   require('remove-trailing-zeros')
 const { RateLimiterMemory, RateLimiterUnion } = require('rate-limiter-flexible')
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -38,8 +38,9 @@ import { scheduleJob } from 'node-schedule'
 import WebSocketServer from 'websocket'
 import WS from 'ws'
 import Helmet from 'helmet'
+import { config } from 'dotenv'
 
-require('dotenv').config() // load variables from .env into the environment
+config() // load variables from .env into the environment
 require('console-stamp')(console)
 
 const configPaths: ConfigPaths = readConfigPathsFromENV()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -36,6 +36,7 @@ import { IpFilter } from 'express-ipfilter'
 import { IpDeniedError } from 'express-ipfilter'
 import { scheduleJob } from 'node-schedule'
 import WebSocketServer from 'websocket'
+import WS from 'ws'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -43,7 +44,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const WS =                    require('ws')
 const Helmet =                require('helmet')
 const RemoveTrailingZeros =   require('remove-trailing-zeros')
 const { RateLimiterMemory, RateLimiterUnion } = require('rate-limiter-flexible')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -40,6 +40,7 @@ import WS from 'ws'
 import Helmet from 'helmet'
 import { config } from 'dotenv'
 import consoleStamp from 'console-stamp'
+import { RateLimiterMemory } from 'rate-limiter-flexible'
 
 config() // load variables from .env into the environment
 consoleStamp(console)
@@ -48,7 +49,6 @@ const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
 const RemoveTrailingZeros =   require('remove-trailing-zeros')
-const { RateLimiterMemory, RateLimiterUnion } = require('rate-limiter-flexible')
 
 // lowdb init
 const order_db: OrderDB =  lowdb(new FileSync<OrderSchema>('db.json'))

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,9 +39,10 @@ import WebSocketServer from 'websocket'
 import WS from 'ws'
 import Helmet from 'helmet'
 import { config } from 'dotenv'
+import consoleStamp from 'console-stamp'
 
 config() // load variables from .env into the environment
-require('console-stamp')(console)
+consoleStamp(console)
 
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,6 +34,7 @@ import Express from 'express'
 import Cors from 'cors'
 import { IpFilter } from 'express-ipfilter'
 import { IpDeniedError } from 'express-ipfilter'
+import { scheduleJob } from 'node-schedule'
 
 require('dotenv').config() // load variables from .env into the environment
 require('console-stamp')(console)
@@ -41,7 +42,6 @@ require('console-stamp')(console)
 const configPaths: ConfigPaths = readConfigPathsFromENV()
 const test_override_http = !process.env.OVERRIDE_USE_HTTP
 
-const Schedule =              require('node-schedule')
 const WebSocketServer =       require('websocket').server
 const WS =                    require('ws')
 const Helmet =                require('helmet')
@@ -100,7 +100,7 @@ if (logdata.length == 0) {
 }
 
 // Stat file scheduler
-Schedule.scheduleJob('0 0 * * *', () => {
+scheduleJob('0 0 * * *', () => {
   appendFile(rpcCount)
   rpcCount = 0
   // update latest logdata from file
@@ -144,7 +144,7 @@ proxyLogSettings(console.log, settings)
 // Periodically check, recover and remove old invactive olders
 if (settings.use_tokens) {
   // Each hour
-  Schedule.scheduleJob('0 * * * *', () => {
+  scheduleJob('0 * * * *', () => {
     checkOldOrders()
   })
 }


### PR DESCRIPTION
Moves to `import` over `require` to get type-goodiness for the remaining parts of the imported libraries.

Had to bump Helmet to get type declerations, also had to add a few @type dependencies. Left `RemoveTrailingZeros` and fixes that in a separate PR.