### PR TITLE
Added use_work_peers setting

### DIFF
--- a/settings.json.default
+++ b/settings.json.default
@@ -21,6 +21,7 @@
   "use_cors":               true,
   "use_dpow":               false,
   "use_bpow":               false,
+  "use_work_peers":         false,
   "disable_watch_work":     false,
   "enable_prometheus_for_ips": [],
   "allowed_commands":       [

--- a/src/__test__/proxy_default.test.ts
+++ b/src/__test__/proxy_default.test.ts
@@ -17,6 +17,7 @@ const expectedDefaultSettings = [
     'Use websocket system: false',
     'Use dPoW: false',
     'Use bPoW: false',
+    'Use work peers: false',
     'Disabled watch_work for process: false',
     'Listen on http: true',
     'Listen on https: false',
@@ -30,6 +31,6 @@ test('log proxy settings with no config', () => {
     let settings: string[] = []
     const readSettings: ProxySettings = readProxySettings('path-does-not-exist')
     proxyLogSettings((setting: string) => settings.push(setting), readSettings)
-    expect(settings.length).toBe(23);
+    expect(settings.length).toBe(24);
     expect(settings).toStrictEqual(expectedDefaultSettings)
 });

--- a/src/__test__/proxy_file.test.ts
+++ b/src/__test__/proxy_file.test.ts
@@ -18,6 +18,7 @@ const expectedSettingsWithFile = [
     'Use websocket system: false',
     'Use dPoW: false',
     'Use bPoW: false',
+    'Use work peers: false',
     'Disabled watch_work for process: false',
     'Listen on http: true',
     'Listen on https: false',
@@ -94,7 +95,7 @@ test('log proxy settings with default config from file', () => {
     let settings: string[] = []
     const readSettings = readProxySettings(getTestPath(settingsFilePath))
     proxyLogSettings((setting: string) => settings.push(setting), readSettings)
-    expect(settings.length).toBe(28);
+    expect(settings.length).toBe(29);
     expect(settings).toStrictEqual(expectedSettingsWithFile)
 })
 

--- a/src/node-api/proxy-api.ts
+++ b/src/node-api/proxy-api.ts
@@ -9,6 +9,7 @@ export interface ProxyRPCRequest {
     amount: string
     watch_work: string
     difficulty: string | undefined
+    use_peers: string | undefined
     user: string | undefined
     api_key: string | undefined
     timeout: number

--- a/src/proxy-settings.ts
+++ b/src/proxy-settings.ts
@@ -71,6 +71,8 @@ export default interface ProxySettings {
     use_dpow: boolean;
     // if allow work_generate to be done by BoomPoW intead of local node. Work will consume 10 token points. If "difficulty" is not provided with the work_generate request the "network current" will be used. (bpow will be used primary to dpow) (requires work_generate in allowed_commands and credentials to be set in pow_creds.json)
     use_bpow: boolean;
+    // if allow work_generate implicitly add "use_peers": "true" to the request to use work_peers configured in the nano node.
+    use_work_peers: boolean;
     // file path for pub cert file
     https_cert: string;
     // file path for private key file
@@ -134,6 +136,7 @@ export function proxyLogSettings(logger: (...data: any[]) => void, settings: Pro
     logger("Use websocket system: " + settings.use_websocket)
     logger("Use dPoW: " + settings.use_dpow)
     logger("Use bPoW: " + settings.use_bpow)
+    logger("Use work peers: " + settings.use_work_peers)
     logger("Disabled watch_work for process: " + settings.disable_watch_work)
     logger("Listen on http: " + settings.use_http)
     logger("Listen on https: " + settings.use_https)
@@ -196,6 +199,7 @@ export function readProxySettings(settingsPath: string): ProxySettings {
         use_cors: true,
         use_dpow: false,
         use_bpow: false,
+        use_work_peers: false,
         https_cert: '',
         https_key: '',
         allowed_commands: [],


### PR DESCRIPTION
This is used to implicitly add "use_peers": "true" to work_generate requests to the node to make us of work_peers configured in the node.

See also: https://docs.nano.org/integration-guides/work-generation/#nodework_peers