### PR TITLE
Websocket revamped

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ The proxy server is configured via the **settings.json** file found in the serve
 * **use_ip_blacklist:** If always blocking certain IPs set in <ip_blacklist> [true/false]
 * **use_tokens** If activating the token system for purchase via Nano [true/false] (more information further down)
 * **use_websocket** If activating the websocket system [true/false] (more information further down)
+* **allow_websocket_all** If allowing users to subscribe to ALL accounts (more traffic) [true/false]
 * **use_cors** If handling cors policy here, if not taken care of in upstream proxy (cors_whitelist=[] means allow ANY ORIGIN)
 * **use_dpow** If allow work_generate to be done by dPoW instead of local node. Work will consume 10 token points. If "difficulty" is not provided with the work_generate request the "default send difficulty" will be used. (The priority order is bpow > dpow > work server. If all three are set to false, it will use the node to generate work) (requires work_generate in allowed_commands and credentials to be set in pow_creds.json)
 * **use_bpow** If allow work_generate to be done by BoomPoW intead of local node. Work will consume 10 token points. If "difficulty" is not provided with the work_generate request the "default send difficulty" will be used. (The priority order is bpow > dpow > work server. If all three are set to false, it will use the node to generate work) (requires work_generate in allowed_commands and credentials to be set in pow_creds.json)

--- a/demo_clients/websocket_js/client.js
+++ b/demo_clients/websocket_js/client.js
@@ -7,9 +7,9 @@ function sleep_simple(ms) {
 
 var socket_nano
 
-function callWebsocket() {
+function callWebsocket(update) {
   var nanoWebsocketOffline = false
-  let tracked_accounts = document.getElementById("myInput").value.split(',')
+  let tracked_accounts = document.getElementById("myInput").value.replace(" ", "").split(',')
 
   // Websocket for NANO with automatic reconnect
   async function socket_sleep(sleep=5000) {
@@ -32,11 +32,13 @@ function callWebsocket() {
     nanoWebsocketOffline = false
     //Subscribe
     let msg = {
-            "action": "subscribe",
-            "topic": "confirmation",
-            "options": {
-              "accounts": tracked_accounts
-            }
+              "action": update ? "update" : "subscribe",
+              "topic": "confirmation",
+              "id": "1",
+              "ack": true,
+              "options": {
+                "accounts": tracked_accounts.length > 0 ? tracked_accounts : []
+              }
           }
     socket_nano.send(JSON.stringify(msg))
   }

--- a/demo_clients/websocket_js/index.html
+++ b/demo_clients/websocket_js/index.html
@@ -109,7 +109,8 @@
       </p>
       <noscript>You need to enable JavaScript to run this app.</noscript>
       <input id="myInput" type="text" placeholder="nano_xxx,nano_yyy"/>
-      <input class="btn" type="button" value="Subscribe" onclick="callWebsocket();" />
+      <input class="btn" type="button" value="Subscribe" onclick="callWebsocket(false);" />
+      <input class="btn" type="button" value="Update" onclick="callWebsocket(true);" />
 
       <textarea id="myTextarea" rows="15"></textarea>
     </div>

--- a/settings.json.default
+++ b/settings.json.default
@@ -18,6 +18,7 @@
   "use_ip_blacklist":       true,
   "use_tokens":             false,
   "use_websocket":          false,
+  "allow_websocket_all":    false,
   "use_cors":               true,
   "use_dpow":               false,
   "use_bpow":               false,

--- a/src/__test__/websockets.test.ts
+++ b/src/__test__/websockets.test.ts
@@ -20,7 +20,7 @@ describe('trackAccount', () => {
 
     test('given valid nano address should return true and write to cache', () => {
         Date.now = jest.fn(() => 1609595113)
-        const res = proxy.trackAccount('192.168.1.1', 'nano_3m497b1ghppe316aiu4o5eednfyueemzjf7a8wye3gi5rjrkpk1p59okghwb')
+        const res = proxy.trackAccount('192.168.1.1', 'nano_3m497b1ghppe316aiu4o5eednfyueemzjf7a8wye3gi5rjrkpk1p59okghwb','1','0')
         expect(res).toBeTruthy()
         const expectedUser: User = {
             ip: '192.168.1.1',
@@ -28,15 +28,17 @@ describe('trackAccount', () => {
                 nano_3m497b1ghppe316aiu4o5eednfyueemzjf7a8wye3gi5rjrkpk1p59okghwb: {
                     "timestamp": 1609595,
                 }
-            }
+            },
+            rpcId: '1',
+            clientId: '0'
         }
         expect(proxy.tracking_db.get('users').value()).toStrictEqual([expectedUser])
     })
 
     test('given same ip and different address, should append new address', () => {
         Date.now = jest.fn(() => 1609595113)
-        proxy.trackAccount('192.168.1.1', 'nano_3m497b1ghppe316aiu4o5eednfyueemzjf7a8wye3gi5rjrkpk1p59okghwb')
-        proxy.trackAccount('192.168.1.1', 'nano_3jsonxwips1auuub94kd3osfg98s6f4x35ksshbotninrc1duswrcauidnue')
+        proxy.trackAccount('192.168.1.1', 'nano_3m497b1ghppe316aiu4o5eednfyueemzjf7a8wye3gi5rjrkpk1p59okghwb','1','0')
+        proxy.trackAccount('192.168.1.1', 'nano_3jsonxwips1auuub94kd3osfg98s6f4x35ksshbotninrc1duswrcauidnue','1','0')
         const expectedUser: User = {
             ip: '192.168.1.1',
             tracked_accounts: {
@@ -46,7 +48,9 @@ describe('trackAccount', () => {
                 nano_3jsonxwips1auuub94kd3osfg98s6f4x35ksshbotninrc1duswrcauidnue: {
                     "timestamp": 1609595,
                 }
-            }
+            },
+            rpcId: '1',
+            clientId: '0'
         }
         expect(proxy.tracking_db.get('users').value()).toStrictEqual([expectedUser])
     })

--- a/src/lowdb-schema.ts
+++ b/src/lowdb-schema.ts
@@ -26,6 +26,8 @@ export interface TrackedAccount {
 
 export interface User {
     ip: string
+    rpcId: string
+    clientId: string
     tracked_accounts: Record<string, TrackedAccount>
 }
 

--- a/src/node-api/websocket-api.ts
+++ b/src/node-api/websocket-api.ts
@@ -1,15 +1,24 @@
 type WSTopic = 'confirmation'
-type WSAction = 'subscribe' | 'unsubscribe' | 'ping' | 'pong'
+type WSAction = 'subscribe' | 'update' | 'unsubscribe' | 'ping' | 'pong'
 
 interface WSNodeSubscribe {
     action: WSAction
     topic: WSTopic
     ack: boolean
+    id: string
     options: {
         all_local_accounts: boolean
         accounts: string[]
     }
 }
+
+interface WSNodeSubscribeAll {
+    action: WSAction
+    topic: WSTopic
+    ack: boolean
+    id: string
+}
+
 interface WSNodeReceive {
     topic: WSTopic
     message: {
@@ -19,6 +28,7 @@ interface WSNodeReceive {
         }
     }
     ack: WSAction
+    id: string
 }
 
 interface WSMessage {

--- a/src/prom-client.ts
+++ b/src/prom-client.ts
@@ -13,6 +13,7 @@ export interface PromClient {
     incDDOS: (ip: string) => void,
     incWebsocketSubscription: (ip: string) => void,
     incWebsocketMessage: (ip: string) => void,
+    incWebsocketMessageAll: (ip: string) => void,
     incAuthorizeAttempt: (username: string, wasAuthorized: boolean) => void
     timeNodeRpc: (action: RPCAction) => MaybeTimedCall,
     timePrice: () => MaybeTimedCall,
@@ -75,6 +76,13 @@ export function createPrometheusClient(): PromClient {
         labelNames: ["ip"]
     })
 
+    let countWebsocketMessageAll = new client.Counter({
+        registers: [register],
+        name: "websocket_message_all",
+        help: "Counts number of times an IP has received a websocket message when subscribed to all",
+        labelNames: ["ip"]
+    })
+
     let countAuthorizedAttempts = new client.Counter({
         registers: [register],
         name: "authorized_attempts",
@@ -110,6 +118,7 @@ export function createPrometheusClient(): PromClient {
         incDDOS: (ip: string) => countDDOS.labels(ip).inc(),
         incWebsocketSubscription: (ip: string) => countWebsocketSubscription.labels(ip).inc(),
         incWebsocketMessage: (ip: string) => countWebsocketMessage.labels(ip).inc(),
+        incWebsocketMessageAll: (ip: string) => countWebsocketMessageAll.labels(ip).inc(),
         incAuthorizeAttempt: (username, wasAuthorized) => countAuthorizedAttempts.labels(username, wasAuthorized ? 'authorized' : 'denied').inc(),
         timeNodeRpc: (action: RPCAction) => rpcHistogram.startTimer({action: action}),
         timePrice: () => priceHistogram.startTimer(),

--- a/src/proxy-settings.ts
+++ b/src/proxy-settings.ts
@@ -66,6 +66,8 @@ export default interface ProxySettings {
     // if enable subscriptions on the node websocket (protected by the proxy)
     use_websocket: boolean;
     // if handling cors policy here, if not taken care of in upstream proxy (cors_whitelist=[] means allow ANY ORIGIN)
+    allow_websocket_all: boolean;
+    // If allowing users to subscribe to ALL accounts (more traffic)
     use_cors: boolean;
     // if allow work_generate to be done by dPoW instead of local node. Work will consume 10 token points. If "difficulty" is not provided with the work_generate request the "default send difficulty" will be used. (The priority order is bpow > dpow > work server. If all three are set to false, it will use the node to generate work) (requires work_generate in allowed_commands and credentials to be set in pow_creds.json)
     use_dpow: boolean;
@@ -127,6 +129,7 @@ export function proxyLogSettings(logger: (...data: any[]) => void, settings: Pro
         logger("Websocket http port: " + String(settings.websocket_http_port))
         logger("Websocket https port: " + String(settings.websocket_https_port))
         logger("Websocket nax accounts: " + String(settings.websocket_max_accounts))
+        logger("Allow websocket subscribe all: " + settings.allow_websocket_all)
     }
     logger("Use authentication: " + settings.use_auth)
     logger("Use slow down: " + settings.use_slow_down)
@@ -199,6 +202,7 @@ export function readProxySettings(settingsPath: string): ProxySettings {
         use_ip_blacklist: false,
         use_tokens: false,
         use_websocket: false,
+        allow_websocket_all: false,
         use_cors: true,
         use_dpow: false,
         use_bpow: false,


### PR DESCRIPTION
* Support "update" action (but will be "subscribe" to the node)
* Proper handling of both local ID and user ID
* Allow subscribing to ALL via custom setting
* Give error when subscribing to all is disallowed
* Proper acknowledge subscription when the node responds

Fixing #96,#88

The websocket user will now contain both the internal rpcId for proper node websocket tracking and the requested clientId that will be part of the acknowledge-response. If subscribing to all, it will be using the "all" label.
![image](https://user-images.githubusercontent.com/2406720/121768400-54807080-cb5e-11eb-9f8b-0855d0b2cdb2.png)
