### PR TITLE
Limit accounts_pending and accounts_balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The proxy server is configured via the **settings.json** file found in the serve
 * **enable_prometheus_for_ips:** IP addresses to enable prometheus for. Typically ["127.0.0.1"] but can also be a combination of ipv4/ipv6 CIDR subnets like ["127.0.0.1", "::1/128", "172.16.0.0/12"] [comma separated list]
 * **allowed_commands:** A list of RPC actions to allow [list]
 * **cached_commands:** A list of commands [key] that will be cached for corresponding duration in seconds as [value]
-* **limited_commands:** A list of commands [key] to limit the output response for with max count as [value]
+* **limited_commands:** A list of commands [key] to limit the output response for with max count as [value]. Also limits account arrays such as accounts_pending, which also limit the pending count per account as value*10.
 * **ip_blacklist:** A list of IPs to always block. Also supports CIDR like ["172.16.0.0/12"]. If calling from localhost you can test this with ["127.0.0.1"] (::ffff:127.0.0.1 for ipv6) [comma separated list]
 * **slow_down:** Contains the settings for slowing down requests. The rolling time slot is defined with <time_window> [ms]. When number of requests in that slot is exceeding <request_limit> it will start slowing down requests with increments of <delay_increment> [ms] with a maximum total delay defined in <max_delay> [ms]
 * **rate_limiter:** Contains the settings for the rate limiter. The rolling time slot is defined with <time_window> [ms]. When number of requests in that slot is exceeding <request_limit> it will block the IP until the time slot has passed. Then the IP can start requesting again. To permanently ban IPs they have to be manually added to <ip_blacklist> and activating <use_ip_blacklist>.

--- a/settings.json.default
+++ b/settings.json.default
@@ -73,6 +73,8 @@
   "limited_commands":       {
     "account_history":        500,
     "accounts_frontiers":     500,
+    "accounts_balances":      500,
+    "accounts_pending":       50,
     "chain":                  500,
     "frontiers":              500,
     "pending":                500

--- a/src/__test__/proxy_file.test.ts
+++ b/src/__test__/proxy_file.test.ts
@@ -72,6 +72,8 @@ const expectedSettingsWithFile = [
     '\n' +
     'account_history : 500\n' +
     'accounts_frontiers : 500\n' +
+    'accounts_balances : 500\n' +
+    'accounts_pending : 50\n' +
     'chain : 500\n' +
     'frontiers : 500\n' +
     'pending : 500\n',

--- a/src/__test__/user_settings.test.ts
+++ b/src/__test__/user_settings.test.ts
@@ -14,7 +14,7 @@ test('parseUserSettings should parse to Map', async () => {
     expect(userSettings).toBeDefined()
     expect(userSettings.allowed_commands.length).toBe(4)
     expect(Object.entries(userSettings.cached_commands).length).toBe(1)
-    expect(Object.entries(userSettings.limited_commands).length).toBe(5)
+    expect(Object.entries(userSettings.limited_commands).length).toBe(7)
 })
 
 afterAll(() => deleteConfigFiles(filePaths))

--- a/src/node-api/proxy-api.ts
+++ b/src/node-api/proxy-api.ts
@@ -1,6 +1,6 @@
 import {TokenAPIActions} from "./token-api";
 
-export type RPCAction = TokenAPIActions | 'mnano_to_raw' | 'mnano_from_raw' | 'process' | 'work_generate' | 'price' | 'verified_accounts' | 'accounts_frontiers'
+export type RPCAction = TokenAPIActions | 'mnano_to_raw' | 'mnano_from_raw' | 'process' | 'work_generate' | 'price' | 'verified_accounts' | 'accounts_frontiers' | 'accounts_balances' | 'accounts_pending'
 
 export interface ProxyRPCRequest {
     action: RPCAction

--- a/user_settings.json.default
+++ b/user_settings.json.default
@@ -14,6 +14,8 @@
     "limited_commands":       {
       "account_history":      50,
       "accounts_frontiers":   50,
+      "accounts_balances":    500,
+      "accounts_pending":     50,
       "chain":                50,
       "frontiers":            50,
       "pending":              50


### PR DESCRIPTION
Will truncate the input account array the same way as accounts_frontiers. The accounts_pending is a bit special since it can also contain a count limit per account. To keep the total amount of response object similar to the other, the default array limit is 50 and the pending count per account is 50*10=500. Combined it becomes 500*50 if all accounts have 50 pending in them.