### PR TITLE
Add receivable actions

### DIFF
--- a/settings.json.default
+++ b/settings.json.default
@@ -51,6 +51,8 @@
     "key_create",
     "pending",
     "pending_exists",
+    "receivable",
+    "receivable_exists",
     "process",
     "representatives",
     "representatives_online",


### PR DESCRIPTION
Add "receivable" and "receivable_exists" actions to default settings following Nano Node V23.0 where "pending" and "pending_exists" are deprecated.